### PR TITLE
Add resolution modes for 4:3 games

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -205,12 +205,22 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 	{
 		// Get the visible width of the activity
 	    double visibleWidth = getWindow().getDecorView().getWidth();
+	    double visibleHeight = getWindow().getDecorView().getHeight();
 	    
 	    ViewGroup.LayoutParams lp = sv.getLayoutParams();
 	    
+	    double vidRatio = vidHeight / vidWidth;
+	    double visibleRatio = visibleHeight / visibleWidth;
+
 	    // Calculate the new size of the SurfaceView
-	    lp.width = (int) visibleWidth;
-	    lp.height = (int) ((vidHeight / vidWidth) * visibleWidth);
+	    if (vidRatio < visibleRatio) {
+		    lp.width = (int) visibleWidth;
+		    lp.height = (int) ((vidHeight / vidWidth) * visibleWidth);
+	    }
+	    else {
+		    lp.width = (int) ((vidWidth / vidHeight) * visibleHeight);
+		    lp.height = (int) visibleHeight;
+	    }
 
 	    // Apply the size change
 	    sv.setLayoutParams(lp);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -14,6 +14,9 @@ public class PreferenceConfiguration {
     private static final String HOST_AUDIO_PREF_STRING = "checkbox_host_audio";
     private static final String DEADZONE_PREF_STRING = "seekbar_deadzone";
 
+    private static final int BITRATE_DEFAULT_640_480_30 = 1;
+    private static final int BITRATE_DEFAULT_800_600_30 = 2;
+    private static final int BITRATE_DEFAULT_1024_768_30 = 4;
     private static final int BITRATE_DEFAULT_720_30 = 5;
     private static final int BITRATE_DEFAULT_720_60 = 10;
     private static final int BITRATE_DEFAULT_1080_30 = 10;
@@ -39,7 +42,16 @@ public class PreferenceConfiguration {
     public boolean stretchVideo, enableSops, playHostAudio, disableWarnings;
 
     public static int getDefaultBitrate(String resFpsString) {
-        if (resFpsString.equals("720p30")) {
+        if (resFpsString.equals("640_480_30")) {
+            return BITRATE_DEFAULT_640_480_30;
+        }
+        else if (resFpsString.equals("800_600_30")) {
+            return BITRATE_DEFAULT_800_600_30;
+        }
+        else if (resFpsString.equals("1024_768_30")) {
+            return BITRATE_DEFAULT_1024_768_30;
+        }
+        else if (resFpsString.equals("720p30")) {
             return BITRATE_DEFAULT_720_30;
         }
         else if (resFpsString.equals("720p60")) {
@@ -61,7 +73,16 @@ public class PreferenceConfiguration {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
         String str = prefs.getString(RES_FPS_PREF_STRING, DEFAULT_RES_FPS);
-        if (str.equals("720p30")) {
+        if (str.equals("640_480_30")) {
+            return BITRATE_DEFAULT_640_480_30;
+        }
+        else if (str.equals("800_600_30")) {
+            return BITRATE_DEFAULT_800_600_30;
+        }
+        else if (str.equals("1024_768_30")) {
+            return BITRATE_DEFAULT_1024_768_30;
+        }
+        else if (str.equals("720p30")) {
             return BITRATE_DEFAULT_720_30;
         }
         else if (str.equals("720p60")) {
@@ -104,7 +125,22 @@ public class PreferenceConfiguration {
 
         config.bitrate = prefs.getInt(BITRATE_PREF_STRING, getDefaultBitrate(context));
         String str = prefs.getString(RES_FPS_PREF_STRING, DEFAULT_RES_FPS);
-        if (str.equals("720p30")) {
+        if (str.equals("640_480_30")) {
+            config.width = 640;
+            config.height = 480;
+            config.fps = 30;
+        }
+        else if (str.equals("800_600_30")) {
+            config.width = 800;
+            config.height = 600;
+            config.fps = 30;
+        }
+        else if (str.equals("1024_768_30")) {
+            config.width = 1024;
+            config.height = 768;
+            config.fps = 30;
+        }
+        else if (str.equals("720p30")) {
             config.width = 1280;
             config.height = 720;
             config.fps = 30;

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="resolution_names">
+        <item>640x480 - 30 FPS</item>
+        <item>800x600 - 30 FPS</item>
+        <item>1024x768 - 30 FPS</item>
         <item>720p - 30 FPS</item>
         <item>720p - 60 FPS</item>
         <item>1080p - 30 FPS</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="resolution_names">
+        <item>640x480 30 FPS</item>
+        <item>800x600 30 FPS</item>
+        <item>1024x768 30 FPS</item>
         <item>720p 30 FPS</item>
         <item>720p 60 FPS</item>
         <item>1080p 30 FPS</item>
         <item>1080p 60 FPS</item>
     </string-array>
     <string-array name="resolution_values" translatable="false">
+        <item>640_480_30</item>
+        <item>800_600_30</item>
+        <item>1024_768_30</item>
         <item>720p30</item>
         <item>720p60</item>
         <item>1080p30</item>


### PR DESCRIPTION
I have added resolution modes for 4:3 games and fixed the resizing code to handle 4:3 resolutions on wide-screen devices properly.
These modes are necessary for playing 4:3 games (mostly old ones) with correct aspect ratio.