### PR TITLE
Add basic building instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ This project is being actively developed at [XDA Developers](http://forum.xda-de
 1. Fork us
 2. Write code
 3. Send Pull Requests
+Building
+
+##Buidling
+* Install Android Studio and the Android NDK
+* Run git submodule update --init --recursive from within moonlight-android/
+* Build the APK using Android Studio
 
 ##Authors
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ This project is being actively developed at [XDA Developers](http://forum.xda-de
 1. Fork us
 2. Write code
 3. Send Pull Requests
-Building
 
-##Buidling
+##Building
 * Install Android Studio and the Android NDK
-* Run git submodule update --init --recursive from within moonlight-android/
+* Run ‘git submodule update --init --recursive’ from within moonlight-android/
+* In moonlight-android/, create a file called ‘local.properties’. Add an ‘ndk.dir=’ property to the local.properties file and set it equal to your NDK directory.
 * Build the APK using Android Studio
 
 ##Authors


### PR DESCRIPTION
Added instructions to build APK for developers. Included getting submodules and installing NDK.