### PR TITLE
Fixed typo in NAL parser

### DIFF
--- a/LuaScripts/NALParser.lua
+++ b/LuaScripts/NALParser.lua
@@ -20,7 +20,7 @@ function p_h264raw.dissector(buf, pkt, root)
 
 	local i = 0
 	local data_start = -1
-    while i < buf:len do
+    while i < buf:len() do
 		-- Make sure we have a potential start sequence and type
         if buf:len() - i < 5 then
             -- We need more data


### PR DESCRIPTION
Added a missing "()" in the NAL parser script