### PR TITLE
Fix issue with ipega controller not capturing keypresses on Samsung Phones

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -575,8 +575,13 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         }
 
         boolean handled = false;
-        if (event.getDevice() == null ||
-                event.getDevice().getKeyboardType() != InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+
+        boolean detectedGamepad = event.getDevice() == null ? false :
+                ((event.getDevice().getSources() & InputDevice.SOURCE_JOYSTICK) != 0 ||
+                        (event.getDevice().getSources() & InputDevice.SOURCE_GAMEPAD) != 0);
+        if (detectedGamepad || (event.getDevice() == null ||
+                event.getDevice().getKeyboardType() != InputDevice.KEYBOARD_TYPE_ALPHABETIC
+        )) {
             // Always try the controller handler first, unless it's an alphanumeric keyboard device.
             // Otherwise, controller handler will eat keyboard d-pad events.
             handled = controllerHandler.handleButtonDown(event);
@@ -614,8 +619,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         }
 
         boolean handled = false;
-        if (event.getDevice() == null ||
-                event.getDevice().getKeyboardType() != InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+        boolean detectedGamepad = event.getDevice() == null ? false :
+                ((event.getDevice().getSources() & InputDevice.SOURCE_JOYSTICK) != 0 ||
+                        (event.getDevice().getSources() & InputDevice.SOURCE_GAMEPAD) != 0);
+        if (detectedGamepad || (event.getDevice() == null ||
+                event.getDevice().getKeyboardType() != InputDevice.KEYBOARD_TYPE_ALPHABETIC
+        )) {
             // Always try the controller handler first, unless it's an alphanumeric keyboard device.
             // Otherwise, controller handler will eat keyboard d-pad events.
             handled = controllerHandler.handleButtonUp(event);


### PR DESCRIPTION
See #385#. 
I was having an issue with my controller not working on Samsung phones. I think this method should try and capture all events if it detects a gamepad. This resolved the issue for me. 