### PR TITLE
Virtual L3 R3 Buttons

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerConfigurationLoader.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerConfigurationLoader.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.util.DisplayMetrics;
 
 import com.limelight.nvstream.input.ControllerPacket;
+import com.limelight.preferences.PreferenceConfiguration;
 
 public class VirtualControllerConfigurationLoader {
     private static final String PROFILE_PATH = "profiles";
@@ -146,109 +147,129 @@ public class VirtualControllerConfigurationLoader {
     public static void createDefaultLayout(final VirtualController controller, final Context context) {
 
         DisplayMetrics screen = context.getResources().getDisplayMetrics();
+        PreferenceConfiguration config = PreferenceConfiguration.readPreferences(context);
 
         // NOTE: Some of these getPercent() expressions seem like they can be combined
         // into a single call. Due to floating point rounding, this isn't actually possible.
 
-        controller.addElement(createDigitalPad(controller, context),
-                getPercent(5, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels),
-                getPercent(30, screen.widthPixels),
-                getPercent(40, screen.heightPixels)
-        );
+        if (!config.onlyL3R3)
+        {
+            controller.addElement(createDigitalPad(controller, context),
+                    getPercent(5, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels),
+                    getPercent(30, screen.widthPixels),
+                    getPercent(40, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.A_FLAG, 0, 1, "A", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels) + getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels) + 2 * getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.B_FLAG, 0, 1, "B", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels) + 2 * getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels) + getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.X_FLAG, 0, 1, "X", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels) + getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.Y_FLAG, 0, 1, "Y", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels) + getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createLeftTrigger(
+                    0, "LT", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createRightTrigger(
+                    0, "RT", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels) + 2 * getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.LB_FLAG, 0, 1, "LB", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels) + 2 * getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.RB_FLAG, 0, 1, "RB", -1, controller, context),
+                    getPercent(BUTTON_BASE_X, screen.widthPixels) + 2 * getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_BASE_Y, screen.heightPixels) + 2 * getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                    getPercent(BUTTON_WIDTH, screen.widthPixels),
+                    getPercent(BUTTON_HEIGHT, screen.heightPixels)
+            );
+
+            controller.addElement(createLeftStick(controller, context),
+                    getPercent(5, screen.widthPixels),
+                    getPercent(50, screen.heightPixels),
+                    getPercent(40, screen.widthPixels),
+                    getPercent(50, screen.heightPixels)
+            );
+
+            controller.addElement(createRightStick(controller, context),
+                    getPercent(55, screen.widthPixels),
+                    getPercent(50, screen.heightPixels),
+                    getPercent(40, screen.widthPixels),
+                    getPercent(50, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.BACK_FLAG, 0, 2, "BACK", -1, controller, context),
+                    getPercent(40, screen.widthPixels),
+                    getPercent(90, screen.heightPixels),
+                    getPercent(10, screen.widthPixels),
+                    getPercent(10, screen.heightPixels)
+            );
+
+            controller.addElement(createDigitalButton(
+                    ControllerPacket.PLAY_FLAG, 0, 3, "START", -1, controller, context),
+                    getPercent(40, screen.widthPixels) + getPercent(10, screen.widthPixels),
+                    getPercent(90, screen.heightPixels),
+                    getPercent(10, screen.widthPixels),
+                    getPercent(10, screen.heightPixels)
+            );
+        }
 
         controller.addElement(createDigitalButton(
-                ControllerPacket.A_FLAG, 0, 1, "A", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels)+getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels)+2*getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                ControllerPacket.LS_CLK_FLAG, 0, 1, "L3", -1, controller, context),
+                getPercent(2, screen.widthPixels),
+                getPercent(80, screen.heightPixels),
                 getPercent(BUTTON_WIDTH, screen.widthPixels),
                 getPercent(BUTTON_HEIGHT, screen.heightPixels)
         );
 
         controller.addElement(createDigitalButton(
-                ControllerPacket.B_FLAG, 0, 1, "B", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels)+2*getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels)+getPercent(BUTTON_HEIGHT, screen.heightPixels),
+                ControllerPacket.RS_CLK_FLAG, 0, 1, "R3", -1, controller, context),
+                getPercent(89, screen.widthPixels),
+                getPercent(80, screen.heightPixels),
                 getPercent(BUTTON_WIDTH, screen.widthPixels),
                 getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createDigitalButton(
-                ControllerPacket.X_FLAG, 0, 1, "X", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels)+getPercent(BUTTON_HEIGHT, screen.heightPixels),
-                getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createDigitalButton(
-                ControllerPacket.Y_FLAG, 0, 1, "Y", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels)+getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels),
-                getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createLeftTrigger(
-                        0, "LT", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels),
-                getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createRightTrigger(
-                0, "RT", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels)+2*getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels),
-                getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createDigitalButton(
-                ControllerPacket.LB_FLAG, 0, 1, "LB", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels)+2*getPercent(BUTTON_HEIGHT, screen.heightPixels),
-                getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createDigitalButton(
-                ControllerPacket.RB_FLAG, 0, 1, "RB", -1, controller, context),
-                getPercent(BUTTON_BASE_X, screen.widthPixels)+2*getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_BASE_Y, screen.heightPixels)+2*getPercent(BUTTON_HEIGHT, screen.heightPixels),
-                getPercent(BUTTON_WIDTH, screen.widthPixels),
-                getPercent(BUTTON_HEIGHT, screen.heightPixels)
-        );
-
-        controller.addElement(createLeftStick(controller, context),
-                getPercent(5, screen.widthPixels),
-                getPercent(50, screen.heightPixels),
-                getPercent(40, screen.widthPixels),
-                getPercent(50, screen.heightPixels)
-        );
-
-        controller.addElement(createRightStick(controller, context),
-                getPercent(55, screen.widthPixels),
-                getPercent(50, screen.heightPixels),
-                getPercent(40, screen.widthPixels),
-                getPercent(50, screen.heightPixels)
-        );
-
-        controller.addElement(createDigitalButton(
-                ControllerPacket.BACK_FLAG, 0, 2, "BACK", -1, controller, context),
-                getPercent(40, screen.widthPixels),
-                getPercent(90, screen.heightPixels),
-                getPercent(10, screen.widthPixels),
-                getPercent(10, screen.heightPixels)
-        );
-
-        controller.addElement(createDigitalButton(
-                ControllerPacket.PLAY_FLAG, 0, 3, "START", -1, controller, context),
-                getPercent(40, screen.widthPixels)+getPercent(10, screen.widthPixels),
-                getPercent(90, screen.heightPixels),
-                getPercent(10, screen.widthPixels),
-                getPercent(10, screen.heightPixels)
         );
     }
 

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -22,6 +22,7 @@ public class PreferenceConfiguration {
     private static final String USB_DRIVER_PREF_SRING = "checkbox_usb_driver";
     private static final String VIDEO_FORMAT_PREF_STRING = "video_format";
     private static final String ONSCREEN_CONTROLLER_PREF_STRING = "checkbox_show_onscreen_controls";
+    private static final String ONLY_L3_R3_PREF_STRING = "checkbox_only_show_L3R3";
     private static final String BATTERY_SAVER_PREF_STRING = "checkbox_battery_saver";
 
     private static final int BITRATE_DEFAULT_720_30 = 5;
@@ -45,6 +46,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_USB_DRIVER = true;
     private static final String DEFAULT_VIDEO_FORMAT = "auto";
     private static final boolean ONSCREEN_CONTROLLER_DEFAULT = false;
+    private static final boolean ONLY_L3_R3_DEFAULT = false;
     private static final boolean DEFAULT_BATTERY_SAVER = false;
 
     public static final int FORCE_H265_ON = -1;
@@ -59,6 +61,7 @@ public class PreferenceConfiguration {
     public String language;
     public boolean listMode, smallIconMode, multiController, enable51Surround, usbDriver;
     public boolean onscreenController;
+    public boolean onlyL3R3;
     public boolean batterySaver;
 
     public static int getDefaultBitrate(String resFpsString) {
@@ -200,6 +203,7 @@ public class PreferenceConfiguration {
         config.enable51Surround = prefs.getBoolean(ENABLE_51_SURROUND_PREF_STRING, DEFAULT_ENABLE_51_SURROUND);
         config.usbDriver = prefs.getBoolean(USB_DRIVER_PREF_SRING, DEFAULT_USB_DRIVER);
         config.onscreenController = prefs.getBoolean(ONSCREEN_CONTROLLER_PREF_STRING, ONSCREEN_CONTROLLER_DEFAULT);
+        config.onlyL3R3 = prefs.getBoolean(ONLY_L3_R3_PREF_STRING, ONLY_L3_R3_DEFAULT);
         config.batterySaver = prefs.getBoolean(BATTERY_SAVER_PREF_STRING, DEFAULT_BATTERY_SAVER);
 
         return config;

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -109,6 +109,8 @@
     <string name="category_on_screen_controls_settings">Configuración de controles en pantalla</string>
     <string name="title_checkbox_show_onscreen_controls">Mostrar controles en pantalla</string>
     <string name="summary_checkbox_show_onscreen_controls">Muestra controles virtuales superpuestos en la pantalla táctil</string>
+    <string name="title_only_l3r3">Solo muestra L3 y R3</string>
+    <string name="summary_only_l3r3">Ocultar todo excepto L3 y R3</string>
 
     <string name="category_ui_settings">Configuración de la interfaz</string>
     <string name="title_language_list">Idioma</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -120,6 +120,8 @@
     <string name="category_on_screen_controls_settings">Paramètres des contrôles à l\'écran</string>
     <string name="title_checkbox_show_onscreen_controls">Afficher les commandes à l\'écran</string>
     <string name="summary_checkbox_show_onscreen_controls">Afficher la superposition du contrôleur virtuel sur l\'écran tactile</string>
+    <string name="title_only_l3r3">Montre seulement L3 et R3</string>
+    <string name="summary_only_l3r3">Cacher tout sauf L3 et R3</string>
 
     <string name="category_ui_settings">Paramètres de l\'interface utilisateur</string>
     <string name="title_language_list">Langue</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="category_on_screen_controls_settings">On-screen Controls Settings</string>
     <string name="title_checkbox_show_onscreen_controls">Show on-screen controls</string>
     <string name="summary_checkbox_show_onscreen_controls">Show virtual controller overlay on touchscreen</string>
+    <string name="title_only_l3r3">Only show L3 and R3</string>
+    <string name="summary_only_l3r3">Hide all virtual buttons except L3 and R3</string>
 
     <string name="category_ui_settings">UI Settings</string>
     <string name="title_language_list">Language</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -54,10 +54,17 @@
     <PreferenceCategory android:title="@string/category_on_screen_controls_settings"
         android:key="category_onscreen_controls">
         <CheckBoxPreference
-            android:key="checkbox_show_onscreen_controls"
-            android:title="@string/title_checkbox_show_onscreen_controls"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="check_box_preference_1"
             android:summary="@string/summary_checkbox_show_onscreen_controls"
-            android:defaultValue="false"/>
+            android:title="@string/title_checkbox_show_onscreen_controls" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_only_show_L3R3"
+            android:summary="@string/summary_only_l3r3"
+            android:title="@string/title_only_l3r3" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_host_settings">
         <CheckBoxPreference

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,7 +57,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:defaultValue="false"
-            android:key="check_box_preference_1"
+            android:key="checkbox_show_onscreen_controls"
             android:summary="@string/summary_checkbox_show_onscreen_controls"
             android:title="@string/title_checkbox_show_onscreen_controls" />
         <CheckBoxPreference


### PR DESCRIPTION
This is a relatively simple addition that does two things:

- Adds L3 and R3 virtual buttons (separate from the analog sticks) to the default virtual controller configuration.
- Gives users the option to only show these L3 and R3 virtual buttons.

The rationale behind this change is that many Android gamepads are missing L3 and R3 buttons, but have all other necessary buttons. It's possible to work around this by enabling the virtual controller and double tapping the analog sticks, however, this is a much less cumbersome solution.