### PR TITLE
Compatibility with Android-x86 open source project

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -72,7 +72,8 @@ public class MediaCodecHelper {
 
 		// Blacklist software decoders that don't support H264 high profile,
 		// but exclude the official AOSP and CrOS emulator from this restriction.
-		if (!Build.HARDWARE.equals("ranchu") && !Build.HARDWARE.equals("cheets")) {
+		// also exclude Android x68_64 , Android x86, as well as android TV built on Fugu for compatibility with Android-x86 open source Project
+		if (!Build.HARDWARE.equals("ranchu") && !Build.HARDWARE.equals("cheets") && !Build.HARDWARE.equals("x86_64") && !Build.HARDWARE.equals("fugu") && !Build.HARDWARE.equals("android_x86")) {
 			blacklistedDecoderPrefixes.add("omx.google");
 			blacklistedDecoderPrefixes.add("AVCDecoder");
 		}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -73,7 +73,8 @@ public class MediaCodecHelper {
 		// Blacklist software decoders that don't support H264 high profile,
 		// but exclude the official AOSP and CrOS emulator from this restriction.
 		// also exclude Android x68_64 , Android x86, as well as android TV built on Fugu for compatibility with Android-x86 open source Project
-		if (!Build.HARDWARE.equals("ranchu") && !Build.HARDWARE.equals("cheets") && !Build.HARDWARE.equals("x86_64") && !Build.HARDWARE.equals("fugu") && !Build.HARDWARE.equals("android_x86")) {
+		if (!Build.HARDWARE.equals("ranchu") && !Build.HARDWARE.equals("cheets") && !Build.HARDWARE.equals("x86_64") &&
+				!Build.HARDWARE.equals("fugu") && !Build.HARDWARE.equals("android_x86") && !Build.HARDWARE.equals("cm_android_x86_64")) {
 			blacklistedDecoderPrefixes.add("omx.google");
 			blacklistedDecoderPrefixes.add("AVCDecoder");
 		}


### PR DESCRIPTION
Modifies blacklist conditions for omx.google script to allow omx.google decoders for android-x86 systems