### PR TITLE
Allow the Xbox One controller select button to work without closing t…

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -367,6 +367,11 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             return true;
         }
 
+        //The Xbox controller has a select button that registers as a back button
+        if (devName.contains("Xbox")) {
+            return false;
+        }
+
         // Classify this device as a remote by name if it has no joystick axes
         if (getMotionRangeForJoystickAxis(dev, MotionEvent.AXIS_X) == null &&
                 getMotionRangeForJoystickAxis(dev, MotionEvent.AXIS_Y) == null &&


### PR DESCRIPTION
…he app / window

When using a bluetooth Xbox Controller on an Android 7 device, it seems that the select button is recognised as a back button (Seems the OS treats this button as a back button.)

Adding this statement seems to do the job!

   if (devName.contains("Xbox")) {
           return false;
     }