### PR TITLE
New Touch Analog Stick Implementation

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/LeftAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/LeftAnalogStick.java
@@ -12,6 +12,8 @@ public class LeftAnalogStick extends AnalogStick {
     public LeftAnalogStick(final VirtualController controller, final Context context) {
         super(controller, context, EID_LS);
 
+        strStickSide = "L";
+
         addAnalogStickListener(new AnalogStick.AnalogStickListener() {
             @Override
             public void onMovement(float x, float y) {

--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/RightAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/RightAnalogStick.java
@@ -12,6 +12,8 @@ public class RightAnalogStick extends AnalogStick {
     public RightAnalogStick(final VirtualController controller, final Context context) {
         super(controller, context, EID_RS);
 
+        strStickSide = "R";
+
         addAnalogStickListener(new AnalogStick.AnalogStickListener() {
             @Override
             public void onMovement(float x, float y) {

--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerElement.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerElement.java
@@ -156,11 +156,6 @@ public abstract class VirtualControllerElement extends View {
         invalidate();
     }
 
-    protected boolean getIsEditing() {
-        return virtualController.getControllerMode() == VirtualController.ControllerMode.MoveButtons ||
-                virtualController.getControllerMode() == VirtualController.ControllerMode.ResizeButtons;
-    }
-
     protected int getDefaultColor() {
         if (virtualController.getControllerMode() == VirtualController.ControllerMode.MoveButtons)
             return configMoveColor;

--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerElement.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerElement.java
@@ -156,6 +156,11 @@ public abstract class VirtualControllerElement extends View {
         invalidate();
     }
 
+    protected boolean getIsEditing() {
+        return virtualController.getControllerMode() == VirtualController.ControllerMode.MoveButtons ||
+                virtualController.getControllerMode() == VirtualController.ControllerMode.ResizeButtons;
+    }
+
     protected int getDefaultColor() {
         if (virtualController.getControllerMode() == VirtualController.ControllerMode.MoveButtons)
             return configMoveColor;


### PR DESCRIPTION
Hello, I was testing out Moonlight this week (mostly comparing it to Steam Link and seeing what are the advantages/disavantages), one thing that bothered me was the touch analog stick being fixed was really hard to use.
So I decided to fork the project and implement a stick like most analog in Android games/the way it works in Steam Link:
GTA V with the new analog: https://www.youtube.com/watch?v=4BG2t5v1gHI
How it works: If the user isn't pressing the analog stick, the first touch that actually does press is saved (and the touch id is saved too). Now the analog is relative to the start touch point, instead of being fixed on-screen. The setup changes to be a squared area where the analog works, not the entire analog area.
BTW sorry if the code is not as clean as possible, I'm a C# developer (I tinker with Java from time to time but compared to C# I actually have no experience whatsoever), I tried making it as clean as I knew how to.
![Screenshot_20200220-193552_Moonlight (Debug)](https://user-images.githubusercontent.com/3450776/74987001-faafe080-5418-11ea-8ec9-ae8fa2e0b7fc.jpg)
![Screenshot_20200220-191321_Moonlight (Debug)](https://user-images.githubusercontent.com/3450776/74987009-fdaad100-5418-11ea-983d-1bebd8ba3fe6.jpg)
![Screenshot_20200220-191305_Moonlight (Debug)](https://user-images.githubusercontent.com/3450776/74987015-ff749480-5418-11ea-87cc-f0f0c70126fe.jpg)
![Uploading Screenshot_20200220-191313_Moonlight (Debug).jpg…]()


