### PR TITLE
Allow RT/LT and A/B/X/Y/LB/RB to be triggered together with one finger

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerConfigurationLoader.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualControllerConfigurationLoader.java
@@ -240,7 +240,7 @@ public class VirtualControllerConfigurationLoader {
             );
 
             controller.addElement(createLeftTrigger(
-                    0, "LT", -1, controller, context),
+                    1, "LT", -1, controller, context),
                     screenScale(TRIGGER_L_BASE_X, height),
                     screenScale(TRIGGER_BASE_Y, height),
                     screenScale(TRIGGER_WIDTH, height),
@@ -248,7 +248,7 @@ public class VirtualControllerConfigurationLoader {
             );
 
             controller.addElement(createRightTrigger(
-                    0, "RT", -1, controller, context),
+                    1, "RT", -1, controller, context),
                     screenScale(TRIGGER_R_BASE_X + TRIGGER_DISTANCE, height) + rightDisplacement,
                     screenScale(TRIGGER_BASE_Y, height),
                     screenScale(TRIGGER_WIDTH, height),


### PR DESCRIPTION
As reported by 8116453, while it was possible to press the RT and A buttons with two fingers, it was impossible to do so with one finger in a sliding motion.

This (tiny) change corrects that by setting RT and LT to the same layer as the other face buttons.