### PR TITLE
Disable max operating rate trick for sm7250

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -378,6 +378,7 @@ public class MediaCodecHelper {
             return true;
         }
         boolean result = false;
+        boolean xiaomiDevice = Build.MANUFACTURER.equalsIgnoreCase("xiaomi")
         try{
             BufferedReader br = new BufferedReader (new FileReader("/proc/cpuinfo"));
             String str;
@@ -389,8 +390,8 @@ public class MediaCodecHelper {
                     if (key.equalsIgnoreCase("hardware")){
                         value = sps[1].trim ().toLowerCase();
                         if (value.contains("sm7250")){
-                            result = true;
-                            isXiaomiSnapdragon7250 = true;
+                            result = xiaomiDevice;
+                            isXiaomiSnapdragon7250 = xiaomiDevice;
                             break;
                         }
                     }
@@ -400,7 +401,7 @@ public class MediaCodecHelper {
         }
         catch (Exception ignored){
         }
-        return result && Build.MANUFACTURER.equalsIgnoreCase("xiaomi");
+        return result;
     }
 
     public static boolean decoderSupportsAdaptivePlayback(MediaCodecInfo decoderInfo, String mimeType) {


### PR DESCRIPTION
Hello everyone.
Look at this [issue 783:](https://github.com/moonlight-stream/moonlight-android/issues/783)
I found all Xiaomi  devices with (QCOM Snapdragon 765G/768G ) may crash like Mi 10 Lite 5G & Redmi K30 5G.
The current build only fixed the Mi 10 Lite, but it seems that K30 5G also crash on streaming startup.
Maybe we should disable the Max Operating Rate Trick for all Xiaomi devices with sm7250.

Best regards