### PR TITLE
Fix Spen(Stylus) with Android12

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1235,6 +1235,16 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             return false;
         }
 
+        //DeviceId : 6 is Samsung Spen
+        //Since I only have Samsung devices, I don't know if this means the stylus for all devices.
+        //If you can get information that means stylus, please change the conditional statement
+
+        //Enable pointer capture on non-stylus devices.
+        if (event.getDeviceId() != 6){
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                streamView.requestPointerCapture();
+            }
+        }
         int eventSource = event.getSource();
         if ((eventSource & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
             if (controllerHandler.handleMotionEvent(event)) {

--- a/app/src/main/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProvider.java
+++ b/app/src/main/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProvider.java
@@ -54,6 +54,17 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
         for (int i = 0; i < event.getHistorySize(); i++) {
             x += event.getHistoricalAxisValue(axis, i);
         }
+        //DeviceId : 6 is Samsung Spen
+        //Since I only have Samsung devices, I don't know if this means the stylus for all devices.
+        //If you can get information that means stylus, please change the conditional statement
+
+        //Starting with Android 12, the stylus pen is recognized as a pointing device and works like a mouse.
+        //To prevent this, the pointer capture stops when the stylus pen is detected.
+        if (event.getDeviceId() == 6 ){
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ) {
+                targetView.releasePointerCapture();
+            }
+        }
         return x;
     }
 
@@ -64,6 +75,11 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
         float y = event.getAxisValue(axis);
         for (int i = 0; i < event.getHistorySize(); i++) {
             y += event.getHistoricalAxisValue(axis, i);
+        }
+        if (event.getDeviceId() == 6 ){
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ) {
+                targetView.releasePointerCapture();
+            }
         }
         return y;
     }


### PR DESCRIPTION
Starting with Android 12, the stylus pen is recognized as a pointing device and works like a mouse.

To prevent this, the pointer capture stops when the stylus pen is detected.