### PR TITLE
Fixed the "Failed to open database" error.

### DIFF
--- a/app/src/main/java/com/limelight/computers/ComputerDatabaseManager.java
+++ b/app/src/main/java/com/limelight/computers/ComputerDatabaseManager.java
@@ -18,7 +18,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 
 public class ComputerDatabaseManager {
-    private static final String COMPUTER_DB_NAME = "computers3.db";
+    private static final String COMPUTER_DB_NAME = "computers.db";
     private static final String COMPUTER_TABLE_NAME = "Computers";
     private static final String COMPUTER_UUID_COLUMN_NAME = "UUID";
     private static final String COMPUTER_NAME_COLUMN_NAME = "ComputerName";

--- a/app/src/main/java/com/limelight/computers/LegacyDatabaseReader2.java
+++ b/app/src/main/java/com/limelight/computers/LegacyDatabaseReader2.java
@@ -15,7 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class LegacyDatabaseReader2 {
-    private static final String COMPUTER_DB_NAME = "computers2.db";
+    private static final String COMPUTER_DB_NAME = "computers.db";
     private static final String COMPUTER_TABLE_NAME = "Computers";
 
     private static ComputerDetails getComputerFromCursor(Cursor c) {


### PR DESCRIPTION
When the app tries to open DB an error occurs:
```2022-04-02 03:01:12.081 20641-20641/? E/SQLiteLog: (14) os_unix.c:36945: (2) open(/data/user/0/in.oneplay/databases/computers.db) - 
2022-04-02 03:01:12.084 20641-20641/? E/SQLiteDatabase: Failed to open database '/data/user/0/in.oneplay/databases/computers.db'.
    android.database.sqlite.SQLiteCantOpenDatabaseException: unknown error (Sqlite code 14 SQLITE_CANTOPEN): Could not open database, (OS error - 2:No such file or directory)
        at android.database.sqlite.SQLiteConnection.nativeOpen(Native Method)
        at android.database.sqlite.SQLiteConnection.open(SQLiteConnection.java:231)
        at android.database.sqlite.SQLiteConnection.open(SQLiteConnection.java:213)
        at android.database.sqlite.SQLiteConnectionPool.openConnectionLocked(SQLiteConnectionPool.java:553)
        at android.database.sqlite.SQLiteConnectionPool.open(SQLiteConnectionPool.java:215)
        at android.database.sqlite.SQLiteConnectionPool.open(SQLiteConnectionPool.java:204)
        at android.database.sqlite.SQLiteDatabase.openInner(SQLiteDatabase.java:948)
        at android.database.sqlite.SQLiteDatabase.open(SQLiteDatabase.java:927)
        at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:818)
        at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:765)
        at in.oneplay.computers.LegacyDatabaseReader.migrateAllComputers(LegacyDatabaseReader.java:93)
        at in.oneplay.computers.ComputerDatabaseManager.initializeDb(ComputerDatabaseManager.java:57)
        at in.oneplay.computers.ComputerDatabaseManager.<init>(ComputerDatabaseManager.java:42)
        at in.oneplay.computers.ComputerManagerService.onCreate(ComputerManagerService.java:714)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4521)
        at android.app.ActivityThread.access$2600(ActivityThread.java:296)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2243)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:213)
        at android.app.ActivityThread.main(ActivityThread.java:8178)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
2022-04-02 03:01:12.086 20641-20641/? E/SQLiteLog: (14) os_unix.c:36945: (2) open(/data/user/0/in.oneplay/databases/computers2.db) - 
2022-04-02 03:01:12.086 20641-20641/? E/SQLiteDatabase: Failed to open database '/data/user/0/in.oneplay/databases/computers2.db'.
    android.database.sqlite.SQLiteCantOpenDatabaseException: unknown error (Sqlite code 14 SQLITE_CANTOPEN): Could not open database, (OS error - 2:No such file or directory)
        at android.database.sqlite.SQLiteConnection.nativeOpen(Native Method)
        at android.database.sqlite.SQLiteConnection.open(SQLiteConnection.java:231)
        at android.database.sqlite.SQLiteConnection.open(SQLiteConnection.java:213)
        at android.database.sqlite.SQLiteConnectionPool.openConnectionLocked(SQLiteConnectionPool.java:553)
        at android.database.sqlite.SQLiteConnectionPool.open(SQLiteConnectionPool.java:215)
        at android.database.sqlite.SQLiteConnectionPool.open(SQLiteConnectionPool.java:204)
        at android.database.sqlite.SQLiteDatabase.openInner(SQLiteDatabase.java:948)
        at android.database.sqlite.SQLiteDatabase.open(SQLiteDatabase.java:927)
        at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:818)
        at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:765)
        at in.oneplay.computers.LegacyDatabaseReader2.migrateAllComputers(LegacyDatabaseReader2.java:74)
        at in.oneplay.computers.ComputerDatabaseManager.initializeDb(ComputerDatabaseManager.java:61)
        at in.oneplay.computers.ComputerDatabaseManager.<init>(ComputerDatabaseManager.java:42)
        at in.oneplay.computers.ComputerManagerService.onCreate(ComputerManagerService.java:714)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4521)
        at android.app.ActivityThread.access$2600(ActivityThread.java:296)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2243)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:213)
        at android.app.ActivityThread.main(ActivityThread.java:8178)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)```