### PR TITLE
Add support for Samsung DeX mode desktop mouse(touchpad) events

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1303,7 +1303,8 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                     (event.getPointerCount() >= 1 &&
                             (event.getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE ||
                                     event.getToolType(0) == MotionEvent.TOOL_TYPE_STYLUS ||
-                                    event.getToolType(0) == MotionEvent.TOOL_TYPE_ERASER)))
+                                    event.getToolType(0) == MotionEvent.TOOL_TYPE_ERASER)) ||
+                    eventSource == 12290) // 12290 = Samsung DeX mode desktop mouse
             {
                 int changedButtons = event.getButtonState() ^ lastButtonState;
 


### PR DESCRIPTION
This should fix #1029. Inspiration from [awtk-android](https://github.com/zlgopen/awtk-android/blob/6a73b3b901bbef1096b57a1e935f377daa43b096/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java#L1699).