### PR TITLE
Add support for "8bitdo Sn30 Pro for xCloud" and some minor configs

### DIFF
--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -68,6 +68,8 @@ public class MoonBridge {
     private static AudioRenderer audioRenderer;
     private static VideoDecoderRenderer videoRenderer;
     private static NvConnectionListener connectionListener;
+    private static boolean disableVideo;
+    private static boolean disableAudio;
 
     static {
         System.loadLibrary("moonlight-core");
@@ -159,13 +161,23 @@ public class MoonBridge {
     public static int bridgeDrSubmitDecodeUnit(byte[] decodeUnitData, int decodeUnitLength, int decodeUnitType,
                                                int frameNumber, int frameType,
                                                long receiveTimeMs, long enqueueTimeMs) {
-        if (videoRenderer != null) {
+        if (videoRenderer != null && !disableVideo) {
             return videoRenderer.submitDecodeUnit(decodeUnitData, decodeUnitLength,
                     decodeUnitType, frameNumber, frameType, receiveTimeMs, enqueueTimeMs);
         }
         else {
             return DR_OK;
         }
+    }
+
+    public static void setAudioDisable(boolean value)
+    {
+        disableAudio = value;
+    }
+
+    public static void setVideoDisable(boolean value)
+    {
+        disableVideo = value;
     }
 
     public static int bridgeArInit(int audioConfiguration, int sampleRate, int samplesPerFrame) {
@@ -196,7 +208,7 @@ public class MoonBridge {
     }
 
     public static void bridgeArPlaySample(short[] pcmData) {
-        if (audioRenderer != null) {
+        if (audioRenderer != null && !disableAudio) {
             audioRenderer.playDecodedAudio(pcmData);
         }
     }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -21,6 +21,7 @@ public class PreferenceConfiguration {
     private static final String DISABLE_TOASTS_PREF_STRING = "checkbox_disable_warnings";
     private static final String HOST_AUDIO_PREF_STRING = "checkbox_host_audio";
     private static final String DEADZONE_PREF_STRING = "seekbar_deadzone";
+    private static final String TRIGGERRANGE_PREF_STRING = "seekbar_trigger_range";
     private static final String OSC_OPACITY_PREF_STRING = "seekbar_osc_opacity";
     private static final String LANGUAGE_PREF_STRING = "list_languages";
     private static final String SMALL_ICONS_PREF_STRING = "checkbox_small_icon_mode";
@@ -42,6 +43,8 @@ public class PreferenceConfiguration {
     private static final String VIBRATE_FALLBACK_PREF_STRING = "checkbox_vibrate_fallback";
     private static final String FLIP_FACE_BUTTONS_PREF_STRING = "checkbox_flip_face_buttons";
     private static final String TOUCHSCREEN_TRACKPAD_PREF_STRING = "checkbox_touchscreen_trackpad";
+    private static final String DISABLE_AUDIO_PREF_STRING = "checkbox_disable_audio";
+	  private static final String DISABLE_VIDEO_PREF_STRING = "checkbox_disable_video";
     private static final String LATENCY_TOAST_PREF_STRING = "checkbox_enable_post_stream_toast";
     private static final String FRAME_PACING_PREF_STRING = "frame_pacing";
     private static final String ABSOLUTE_MOUSE_MODE_PREF_STRING = "checkbox_absolute_mouse_mode";
@@ -53,6 +56,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_DISABLE_TOASTS = false;
     private static final boolean DEFAULT_HOST_AUDIO = false;
     private static final int DEFAULT_DEADZONE = 7;
+    private static final int DEFAULT_TRIGGERRANGE = 100;
     private static final int DEFAULT_OPACITY = 90;
     public static final String DEFAULT_LANGUAGE = "default";
     private static final boolean DEFAULT_MULTI_CONTROLLER = true;
@@ -67,6 +71,8 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_MOUSE_EMULATION = true;
     private static final boolean DEFAULT_MOUSE_NAV_BUTTONS = false;
     private static final boolean DEFAULT_UNLOCK_FPS = false;
+    private static final boolean DEFAULT_DISABLE_VIDEO = false;
+    private static final boolean DEFAULT_DISABLE_AUDIO = false;
     private static final boolean DEFAULT_VIBRATE_OSC = true;
     private static final boolean DEFAULT_VIBRATE_FALLBACK = false;
     private static final boolean DEFAULT_FLIP_FACE_BUTTONS = false;
@@ -97,6 +103,7 @@ public class PreferenceConfiguration {
     public int bitrate;
     public int videoFormat;
     public int deadzonePercentage;
+    public int triggerRangePercentage;
     public int oscOpacity;
     public boolean stretchVideo, enableSops, playHostAudio, disableWarnings;
     public String language;
@@ -444,6 +451,8 @@ public class PreferenceConfiguration {
 
         config.deadzonePercentage = prefs.getInt(DEADZONE_PREF_STRING, DEFAULT_DEADZONE);
 
+        config.triggerRangePercentage = prefs.getInt(TRIGGERRANGE_PREF_STRING, DEFAULT_TRIGGERRANGE);
+
         config.oscOpacity = prefs.getInt(OSC_OPACITY_PREF_STRING, DEFAULT_OPACITY);
 
         config.language = prefs.getString(LANGUAGE_PREF_STRING, DEFAULT_LANGUAGE);
@@ -471,6 +480,8 @@ public class PreferenceConfiguration {
         config.touchscreenTrackpad = prefs.getBoolean(TOUCHSCREEN_TRACKPAD_PREF_STRING, DEFAULT_TOUCHSCREEN_TRACKPAD);
         config.enableLatencyToast = prefs.getBoolean(LATENCY_TOAST_PREF_STRING, DEFAULT_LATENCY_TOAST);
         config.absoluteMouseMode = prefs.getBoolean(ABSOLUTE_MOUSE_MODE_PREF_STRING, DEFAULT_ABSOLUTE_MOUSE_MODE);
+        MoonBridge.setAudioDisable(prefs.getBoolean(DISABLE_AUDIO_PREF_STRING, DEFAULT_DISABLE_AUDIO));
+		    MoonBridge.setVideoDisable(prefs.getBoolean(DISABLE_VIDEO_PREF_STRING, DEFAULT_DISABLE_VIDEO));
 
         return config;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,9 @@
     <string name="title_seekbar_deadzone">Adjust analog stick deadzone</string>
     <string name="summary_seekbar_deadzone">Note: Some games can enforce a larger deadzone than what Moonlight is configured to use.</string>
     <string name="suffix_seekbar_deadzone">%</string>
+    <string name="title_seekbar_trigger_range">Adjust trigger press value</string>
+    <string name="suffix_seekbar_trigger_range">%</string>
+    <string name="summary_seekbar_trigger_range">Modify max range for a full pressed (ex. set as 50% when you want press the trigger half-way but registering as a full pressed)</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One USB gamepad driver</string>
     <string name="summary_checkbox_xb1_driver">Enables a built-in USB driver for devices without native Xbox controller support</string>
     <string name="title_checkbox_usb_bind_all">Override native Xbox gamepad support</string>
@@ -226,6 +229,10 @@
     <string name="summary_enable_perf_overlay">Display real-time stream performance information while streaming</string>
     <string name="title_enable_post_stream_toast">Show latency message after streaming</string>
     <string name="summary_enable_post_stream_toast">Display a latency information message after the stream ends</string>
+    <string name="title_disable_video">Disable video output</string>
+    <string name="summary_disable_video">Show a black/blank screen instead</string>
+    <string name="title_disable_audio">Disable audio output</string>
+    <string name="summary_disable_audio">Mute audio</string>
 
     <string name="category_help">Help</string>
     <string name="title_setup_guide">Setup guide</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -59,6 +59,14 @@
             android:summary="@string/summary_seekbar_deadzone"
             android:text="@string/suffix_seekbar_deadzone"
             android:title="@string/title_seekbar_deadzone"/>
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_trigger_range"
+            android:min="0"
+            android:defaultValue="100"
+            android:max="100"
+            android:summary="@string/summary_seekbar_trigger_range"
+            android:text="@string/suffix_seekbar_trigger_range"
+            android:title="@string/title_seekbar_trigger_range"/>
         <CheckBoxPreference
             android:key="checkbox_touchscreen_trackpad"
             android:title="@string/title_checkbox_touchscreen_trackpad"
@@ -211,6 +219,16 @@
             android:title="@string/title_enable_post_stream_toast"
             android:summary="@string/summary_enable_post_stream_toast"
             android:defaultValue="false"/>
+        <CheckBoxPreference
+            android:key="checkbox_disable_video"
+            android:title="@string/title_disable_video"
+            android:summary="@string/summary_disable_video"
+            android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_disable_audio"
+            android:title="@string/title_disable_audio"
+            android:summary="@string/summary_disable_audio"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <!--PreferenceCategory android:title="@string/category_help"
         android:key="category_help">


### PR DESCRIPTION
- Add support for 8bitdo Sn30 Pro for xCloud
- Add trigger custom range in the input category ( reduce trigger movement to X %)
- Add disabled audio/video function in the advanced category (for rare use cases like streaming music only, streaming video only, or stream gamepad input only...)