### PR TITLE
Controller's triggers tweaking

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -1264,8 +1264,12 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         }
 
         if (context.leftTriggerAxis != -1 && context.rightTriggerAxis != -1) {
-            lt = event.getAxisValue(context.leftTriggerAxis);
-            rt = event.getAxisValue(context.rightTriggerAxis);
+            float percentage = prefConfig.triggerRangePercentage;
+            percentage = percentage / 100;
+            lt = event.getAxisValue(context.leftTriggerAxis) / percentage;
+            lt = lt > 1 ? 1 : lt;
+            rt = event.getAxisValue(context.rightTriggerAxis) / percentage;
+            rt = rt > 1 ? 1 : rt;
         }
 
         if (context.hatXAxis != -1 && context.hatYAxis != -1) {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -21,6 +21,7 @@ public class PreferenceConfiguration {
     private static final String DISABLE_TOASTS_PREF_STRING = "checkbox_disable_warnings";
     private static final String HOST_AUDIO_PREF_STRING = "checkbox_host_audio";
     private static final String DEADZONE_PREF_STRING = "seekbar_deadzone";
+    private static final String TRIGGERRANGE_PREF_STRING = "seekbar_trigger_range";
     private static final String OSC_OPACITY_PREF_STRING = "seekbar_osc_opacity";
     private static final String LANGUAGE_PREF_STRING = "list_languages";
     private static final String SMALL_ICONS_PREF_STRING = "checkbox_small_icon_mode";
@@ -54,6 +55,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_HOST_AUDIO = false;
     private static final int DEFAULT_DEADZONE = 7;
     private static final int DEFAULT_OPACITY = 90;
+    private static final int DEFAULT_TRIGGERRANGE = 100;
     public static final String DEFAULT_LANGUAGE = "default";
     private static final boolean DEFAULT_MULTI_CONTROLLER = true;
     private static final boolean DEFAULT_USB_DRIVER = true;
@@ -97,6 +99,7 @@ public class PreferenceConfiguration {
     public int bitrate;
     public int videoFormat;
     public int deadzonePercentage;
+    public int triggerRangePercentage;
     public int oscOpacity;
     public boolean stretchVideo, enableSops, playHostAudio, disableWarnings;
     public String language;
@@ -443,6 +446,8 @@ public class PreferenceConfiguration {
         config.framePacing = getFramePacingValue(context);
 
         config.deadzonePercentage = prefs.getInt(DEADZONE_PREF_STRING, DEFAULT_DEADZONE);
+
+        config.triggerRangePercentage = prefs.getInt(TRIGGERRANGE_PREF_STRING, DEFAULT_TRIGGERRANGE);
 
         config.oscOpacity = prefs.getInt(OSC_OPACITY_PREF_STRING, DEFAULT_OPACITY);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,9 @@
     <string name="title_seekbar_deadzone">Adjust analog stick deadzone</string>
     <string name="summary_seekbar_deadzone">Note: Some games can enforce a larger deadzone than what Moonlight is configured to use.</string>
     <string name="suffix_seekbar_deadzone">%</string>
+    <string name="title_seekbar_trigger_range">Adjust trigger press value</string>
+    <string name="suffix_seekbar_trigger_range">%</string>
+    <string name="summary_seekbar_trigger_range">Modify max range for a full pressed (ex. set as 50% when you want press the trigger half-way but registering as a full pressed)</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One USB gamepad driver</string>
     <string name="summary_checkbox_xb1_driver">Enables a built-in USB driver for devices without native Xbox controller support</string>
     <string name="title_checkbox_usb_bind_all">Override native Xbox gamepad support</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -59,6 +59,14 @@
             android:summary="@string/summary_seekbar_deadzone"
             android:text="@string/suffix_seekbar_deadzone"
             android:title="@string/title_seekbar_deadzone"/>
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_trigger_range"
+            android:min="0"
+            android:defaultValue="100"
+            android:max="100"
+            android:summary="@string/summary_seekbar_trigger_range"
+            android:text="@string/suffix_seekbar_trigger_range"
+            android:title="@string/title_seekbar_trigger_range"/>
         <CheckBoxPreference
             android:key="checkbox_touchscreen_trackpad"
             android:title="@string/title_checkbox_touchscreen_trackpad"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -61,7 +61,7 @@
             android:title="@string/title_seekbar_deadzone"/>
         <com.limelight.preferences.SeekBarPreference
             android:key="seekbar_trigger_range"
-            android:min="0"
+            android:min="1"
             android:defaultValue="100"
             android:max="100"
             android:summary="@string/summary_seekbar_trigger_range"


### PR DESCRIPTION
I have a use case like this with my defect controller:
- Open [gamepadtester](https://gamepad-tester.com/)
- The left trigger registered all the way to 1.0 but the right trigger only registered 0.5-0.6 when fully pressed.
- The problem was affected clearly in racing games, the car couldn't reach full acceleration.
Hence, I make a new tweak option for the controller.  For example, you can adjust to 75% to make moonlight register a 3/4 press trigger as a fully pressed trigger. 
And with this tweak, you can transform an analog trigger into a digital one by lower to a very small % value.
