### PR TITLE
Use BT.709 and full color range as default

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -327,11 +327,11 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     }
 
     public int getPreferredColorSpace() {
-        return MoonBridge.COLORSPACE_REC_601;
+        return MoonBridge.COLORSPACE_REC_709;
     }
 
     public int getPreferredColorRange() {
-        return MoonBridge.COLOR_RANGE_LIMITED;
+        return MoonBridge.COLOR_RANGE_FULL;
     }
 
     public void notifyVideoForeground() {


### PR DESCRIPTION
The change can improve color quality and avoid unnecessary conversion.

Close #1138.