### PR TITLE
Set forceDarkAllowed to false

### DIFF
--- a/app/src/main/res/values-v29/styles.xml
+++ b/app/src/main/res/values-v29/styles.xml
@@ -2,5 +2,7 @@
     <style name="AppBaseTheme" parent="android:Theme.Material">
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <!-- Avoid some systems like MIUI which break the visibility of games title -->
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 </resources>


### PR DESCRIPTION
Some system like MIUI forced inverse color (which cannot be turned off for games with night mode on) causes games without covers to become white, which same as the game title color causes it unreadability, this change prevents that problem.

ref https://stackoverflow.com/questions/63777438/how-to-avoid-forced-dark-theme-in-my-app-when-devices-can-force-it-at-app-level