### PR TITLE
Auto-scale PC and Game Grid Text on supported Android Version

### DIFF
--- a/app/src/main/java/com/limelight/grid/PcGridAdapter.java
+++ b/app/src/main/java/com/limelight/grid/PcGridAdapter.java
@@ -1,6 +1,8 @@
 package com.limelight.grid;
 
 import android.content.Context;
+import android.os.Build;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -64,6 +66,12 @@ public class PcGridAdapter extends GenericGridAdapter<PcView.ComputerObject> {
         else {
             prgView.setVisibility(View.INVISIBLE);
         }
+
+        // Auto-scale text on supported Android versions
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            txtView.setAutoSizeTextTypeUniformWithConfiguration(5, 25, 1, TypedValue.COMPLEX_UNIT_SP);
+        }
+        txtView.setMaxLines(1);
 
         txtView.setText(obj.details.name);
         if (obj.details.state == ComputerDetails.State.ONLINE) {

--- a/app/src/main/java/com/limelight/grid/assets/CachedAppAssetLoader.java
+++ b/app/src/main/java/com/limelight/grid/assets/CachedAppAssetLoader.java
@@ -5,6 +5,8 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
+import android.os.Build;
+import android.util.TypedValue;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
@@ -340,6 +342,13 @@ public class CachedAppAssetLoader {
         if (!cancelPendingLoad(tuple, imgView)) {
             return true;
         }
+
+
+        // Auto-scale text on supported Android versions
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            textView.setAutoSizeTextTypeUniformWithConfiguration(5, 25, 1, TypedValue.COMPLEX_UNIT_SP);
+        }
+        textView.setMaxLines(1);
 
         // Always set the name text so we have it if needed later
         textView.setText(app.getAppName());


### PR DESCRIPTION
My PC's name is "AWESOMESAUCE". Whenever I would launch Moonlight the name of my PC would show up on 2 lines.
This was slightly annoying to me so I sought out to create a fix.

With this change font sizes will now automatically scale depending on the length on text on both the PC and Game Grid Views to fit longer text. This only happens for device with the minimum Android Version. 
Lower devices will still print on one line with truncated text.

I chose an arbitrary min and max font sizes but in my testing they look decent. 
I am open to adjusting these however.

Before
![Before](https://user-images.githubusercontent.com/22644647/208606033-327bec43-08d4-4080-9676-7579a55bccfd.png)

After
![After](https://user-images.githubusercontent.com/22644647/208606085-cd97bf5c-78d6-4455-9861-8c77030a8df8.png)


Short PC name
![short](https://user-images.githubusercontent.com/22644647/208606132-69c1927d-547e-40ad-9aec-2c8e3d781151.png)

Long PC name
![long](https://user-images.githubusercontent.com/22644647/208606150-48f3a820-8f29-4f9a-a898-927a60b48a9b.png)


Short Game name
![short_game](https://user-images.githubusercontent.com/22644647/208606176-7ec795b4-41af-4912-9514-51886de0d6d8.png)

Long Game name
![long_game](https://user-images.githubusercontent.com/22644647/208606198-27855377-c1c2-4bd7-a07d-24dac999942f.png)
