### PR TITLE
Feature/show keyboard android tv

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -210,6 +210,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         // Inflate the content
         setContentView(R.layout.activity_game);
 
+        // Hack: allows use keyboard by dpad or controller
+        getWindow().getDecorView().findViewById(android.R.id.content).setFocusable(true);
+
         // Start the spinner
         spinner = SpinnerDialog.displayDialog(this, getResources().getString(R.string.conn_establishing_title),
                 getResources().getString(R.string.conn_establishing_msg), true);
@@ -1413,6 +1416,10 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     @Override
     public void toggleKeyboard() {
         LimeLog.info("Toggling keyboard overlay");
+
+        // Hack: allows use keyboard by dpad or controller
+        streamView.clearFocus();
+
         InputMethodManager inputManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         inputManager.toggleSoftInput(0, 0);
     }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -42,6 +42,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
     private static final int MAXIMUM_BUMPER_UP_DELAY_MS = 100;
 
     private static final int START_DOWN_TIME_MOUSE_MODE_MS = 750;
+    private static final int SELECT_DOWN_TIME_SHOW_KEYBOARD_MS = 750;
 
     private static final int MINIMUM_BUTTON_DOWN_TIME_MS = 25;
 
@@ -1517,6 +1518,10 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             break;
         case KeyEvent.KEYCODE_BACK:
         case KeyEvent.KEYCODE_BUTTON_SELECT:
+            if ((context.inputMap & ControllerPacket.PLAY_FLAG) != 0 &&
+                    event.getEventTime() - context.selectDownTime > ControllerHandler.SELECT_DOWN_TIME_SHOW_KEYBOARD_MS) {
+                gestures.toggleKeyboard();
+            }
             context.inputMap &= ~ControllerPacket.BACK_FLAG;
             break;
         case KeyEvent.KEYCODE_DPAD_LEFT:
@@ -1660,6 +1665,9 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         case KeyEvent.KEYCODE_BACK:
         case KeyEvent.KEYCODE_BUTTON_SELECT:
             context.hasSelect = true;
+            if (event.getRepeatCount() == 0) {
+                context.selectDownTime = event.getEventTime();
+            }
             context.inputMap |= ControllerPacket.BACK_FLAG;
             break;
         case KeyEvent.KEYCODE_DPAD_LEFT:
@@ -1962,6 +1970,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         public long lastRbUpTime = 0;
 
         public long startDownTime = 0;
+        public long selectDownTime = 0;
 
         @Override
         public void destroy() {


### PR DESCRIPTION
A new functionality has been added that allows to display the keyboard by holding the "select" button. See [Pop up virtual keyboard on Android TV with controller.](https://github.com/moonlight-stream/moonlight-android/issues/1112)

The second commit allows to move cursor on the keyboard by dpad (TV control or controller). If we don't apply this commit the keyboard won't have focus and we won't be able to move the cursor.