### PR TITLE
Compensate for choreographer vsync offset

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -20,6 +20,7 @@ import com.limelight.nvstream.jni.MoonBridge;
 import com.limelight.preferences.PreferenceConfiguration;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
@@ -57,6 +58,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     private ByteBuffer nextInputBuffer;
 
     private Context context;
+    private Activity activity;
     private MediaCodec videoDecoder;
     private Thread rendererThread;
     private boolean needsSpsBitstreamFixup, isExynos4;
@@ -233,13 +235,14 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         this.renderTarget = renderTarget;
     }
 
-    public MediaCodecDecoderRenderer(Context context, PreferenceConfiguration prefs,
+    public MediaCodecDecoderRenderer(Activity activity, PreferenceConfiguration prefs,
                                      CrashListener crashListener, int consecutiveCrashCount,
                                      boolean meteredData, boolean requestedHdr,
                                      String glRenderer, PerfOverlayListener perfListener) {
         //dumpDecoders();
 
-        this.context = context;
+        this.context = activity;
+        this.activity = activity;
         this.prefs = prefs;
         this.crashListener = crashListener;
         this.consecutiveCrashCount = consecutiveCrashCount;
@@ -869,6 +872,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         // Do nothing if we're stopping
         if (stopping) {
             return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            frameTimeNanos -= activity.getWindowManager().getDefaultDisplay().getAppVsyncOffsetNanos();
         }
 
         // Don't render unless a new frame is due. This prevents microstutter when streaming


### PR DESCRIPTION
From [getAppVsyncOffsetNanos()](https://developer.android.com/reference/android/view/Display#getAppVsyncOffsetNanos()) documentation:
> Gets the app VSYNC offset, in nanoseconds. This is a positive value indicating the phase offset of the VSYNC events provided by > Choreographer relative to the display refresh. For example, if Choreographer reports that the refresh occurred at time N, it actually occurred at (N - appVsyncOffset). 

I'm not 100% sure about the root cause, but supplying the vsync timestamp instead of raw choreographer timestamp to `releaseOutputBuffer()` significantly improves frame stability of balanced frame pacing. This happened consistently across all devices I have tested. And it brings balanced frame pacing smoothness on par with "prefer smoothest video".