### PR TITLE
Allow toggling performance overlay while streaming

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -143,6 +143,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     private TextView notificationOverlayView;
     private int requestedNotificationOverlayVisibility = View.GONE;
     private TextView performanceOverlayView;
+    private int requestedPerformanceOverlayVisibility = View.GONE;
 
     private ShortcutHelper shortcutHelper;
 
@@ -377,11 +378,6 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             else {
                 Toast.makeText(this, "HDR requires Android 7.0 or later", Toast.LENGTH_LONG).show();
             }
-        }
-
-        // Check if the user has enabled performance stats overlay
-        if (prefConfig.enablePerfOverlay) {
-            performanceOverlayView.setVisibility(View.VISIBLE);
         }
 
         decoderRenderer = new MediaCodecDecoderRenderer(
@@ -631,10 +627,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                     virtualController.show();
                 }
 
-                if (prefConfig.enablePerfOverlay) {
-                    performanceOverlayView.setVisibility(View.VISIBLE);
-                }
-
+                performanceOverlayView.setVisibility(requestedPerformanceOverlayVisibility);
                 notificationOverlayView.setVisibility(requestedNotificationOverlayVisibility);
 
                 // Update GameManager state to indicate we're out of PiP (gaming, non-interruptible)
@@ -2282,6 +2275,11 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     }
 
     @Override
+    public boolean isPerfOverlayVisible() {
+        return requestedPerformanceOverlayVisibility == View.VISIBLE;
+    }
+
+    @Override
     public void onUsbPermissionPromptStarting() {
         // Disable PiP auto-enter while the USB permission prompt is on-screen. This prevents
         // us from entering PiP while the user is interacting with the OS permission dialog.
@@ -2328,5 +2326,14 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         // ensures that Android properly handles the back key when needed and only open the game
         // menu when the activity would be closed.
         showGameMenu(null);
+    }
+
+    public void togglePerformanceOverlay() {
+        if (requestedPerformanceOverlayVisibility == View.VISIBLE) {
+            requestedPerformanceOverlayVisibility = View.GONE;
+        } else {
+            requestedPerformanceOverlayVisibility = View.VISIBLE;
+        }
+        performanceOverlayView.setVisibility(requestedPerformanceOverlayVisibility);
     }
 }

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -39,12 +39,10 @@ import com.limelight.utils.UiHelper;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.PictureInPictureParams;
 import android.app.Service;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
@@ -66,10 +64,7 @@ import android.view.Display;
 import android.view.InputDevice;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
-import android.view.LayoutInflater;
-import android.view.Menu;
 import android.view.MotionEvent;
-import android.view.SubMenu;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
@@ -78,15 +73,12 @@ import android.view.View.OnSystemUiVisibilityChangeListener;
 import android.view.View.OnTouchListener;
 import android.view.Window;
 import android.view.WindowManager;
-import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.PopupMenu;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import java.io.ByteArrayInputStream;
-import java.io.PipedOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.cert.CertificateException;
@@ -2311,9 +2303,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                     return true;
 
                 // Intercept back key event before android handles it
-                // Always handle the request, the user has to select "Disconnect" within the back menu to actually disconnect
+                // Always handle the request, the user has to select "Disconnect" within the game menu to actually disconnect
                 if (keyCode == keyEvent.KEYCODE_BACK) {
-                    new GameBackMenu(this, conn);
+                    new GameMenu(this, conn);
                     return true;
                 }
             case KeyEvent.ACTION_UP:

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -2315,7 +2315,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     }
 
     public void disconnect() {
-        super.onBackPressed();
+        finish();
     }
 
     @Override

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -4,6 +4,7 @@ package com.limelight;
 import com.limelight.binding.PlatformBinding;
 import com.limelight.binding.audio.AndroidAudioRenderer;
 import com.limelight.binding.input.ControllerHandler;
+import com.limelight.binding.input.GameInputDevice;
 import com.limelight.binding.input.KeyboardTranslator;
 import com.limelight.binding.input.capture.InputCaptureManager;
 import com.limelight.binding.input.capture.InputCaptureProvider;
@@ -2295,6 +2296,11 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     }
 
     @Override
+    public void showGameMenu(GameInputDevice device) {
+        new GameMenu(this, conn, device);
+    }
+
+    @Override
     public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
         switch (keyEvent.getAction()) {
             case KeyEvent.ACTION_DOWN:
@@ -2305,7 +2311,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 // Intercept back key event before android handles it
                 // Always handle the request, the user has to select "Disconnect" within the game menu to actually disconnect
                 if (keyCode == keyEvent.KEYCODE_BACK) {
-                    new GameMenu(this, conn);
+                    showGameMenu(null);
                     return true;
                 }
             case KeyEvent.ACTION_UP:

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1268,8 +1268,16 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 
     @Override
     public boolean handleKeyDown(KeyEvent event) {
-        // Pass-through virtual navigation keys
+        // Handle (virtual) Navigation Keys
         if ((event.getFlags() & KeyEvent.FLAG_VIRTUAL_HARD_KEY) != 0) {
+            // Show Game Menu on back action instead of finishing the activity, the user has to
+            // select "Disconnect" within the game menu to actually disconnect
+            if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+                showGameMenu(null);
+                return true;
+            }
+
+            // Pass-through other navigation keys
             return false;
         }
 
@@ -2304,16 +2312,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
         switch (keyEvent.getAction()) {
             case KeyEvent.ACTION_DOWN:
-                boolean handled = handleKeyDown(keyEvent);
-                if (handled)
-                    return true;
-
-                // Intercept back key event before android handles it
-                // Always handle the request, the user has to select "Disconnect" within the game menu to actually disconnect
-                if (keyCode == keyEvent.KEYCODE_BACK) {
-                    showGameMenu(null);
-                    return true;
-                }
+                return handleKeyDown(keyEvent);
             case KeyEvent.ACTION_UP:
                 return handleKeyUp(keyEvent);
             case KeyEvent.ACTION_MULTIPLE:

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1268,16 +1268,8 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 
     @Override
     public boolean handleKeyDown(KeyEvent event) {
-        // Handle (virtual) Navigation Keys
+        // Pass-through navigation keys
         if ((event.getFlags() & KeyEvent.FLAG_VIRTUAL_HARD_KEY) != 0) {
-            // Show Game Menu on back action instead of finishing the activity, the user has to
-            // select "Disconnect" within the game menu to actually disconnect
-            if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
-                showGameMenu(null);
-                return true;
-            }
-
-            // Pass-through other navigation keys
             return false;
         }
 
@@ -2320,5 +2312,21 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             default:
                 return false;
         }
+    }
+
+    public void disconnect() {
+        super.onBackPressed();
+    }
+
+    @Override
+    public void onBackPressed() {
+        // Instead of "closing" the game activity open the game menu. The user has to select
+        // "Disconnect" within the game menu to actually disconnect from the remote host.
+        //
+        // Use the onBackPressed instead of the onKey function, since the onKey function
+        // also captures events while having the on-screen keyboard open.  Using onBackPressed
+        // ensures that Android properly handles the back key when needed and only open the game
+        // menu when the activity would be closed.
+        showGameMenu(null);
     }
 }

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -39,10 +39,12 @@ import com.limelight.utils.UiHelper;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.PictureInPictureParams;
 import android.app.Service;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
@@ -64,7 +66,10 @@ import android.view.Display;
 import android.view.InputDevice;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.Menu;
 import android.view.MotionEvent;
+import android.view.SubMenu;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
@@ -73,12 +78,15 @@ import android.view.View.OnSystemUiVisibilityChangeListener;
 import android.view.View.OnTouchListener;
 import android.view.Window;
 import android.view.WindowManager;
+import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.PopupMenu;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import java.io.ByteArrayInputStream;
+import java.io.PipedOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.cert.CertificateException;
@@ -2298,7 +2306,16 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
         switch (keyEvent.getAction()) {
             case KeyEvent.ACTION_DOWN:
-                return handleKeyDown(keyEvent);
+                boolean handled = handleKeyDown(keyEvent);
+                if (handled)
+                    return true;
+
+                // Intercept back key event before android handles it
+                // Always handle the request, the user has to select "Disconnect" within the back menu to actually disconnect
+                if (keyCode == keyEvent.KEYCODE_BACK) {
+                    new GameBackMenu(this, conn);
+                    return true;
+                }
             case KeyEvent.ACTION_UP:
                 return handleKeyUp(keyEvent);
             case KeyEvent.ACTION_MULTIPLE:

--- a/app/src/main/java/com/limelight/GameBackMenu.java
+++ b/app/src/main/java/com/limelight/GameBackMenu.java
@@ -1,0 +1,122 @@
+package com.limelight;
+
+import android.app.AlertDialog;
+import android.widget.ArrayAdapter;
+
+import com.limelight.nvstream.NvConnection;
+import com.limelight.nvstream.input.KeyboardPacket;
+
+public class GameBackMenu {
+
+    private final String ACTION_SEND_SPECIAL_KEYS;
+    private final String ACTION_DISCONNECT;
+    private final String ACTION_CANCEL;
+
+    private final String ACTION_SEND_SPECIAL_KEYS_ESC;
+    private final String ACTION_SEND_SPECIAL_KEYS_F11;
+    private final String ACTION_SEND_SPECIAL_KEYS_WIN;
+    private final String ACTION_SEND_SPECIAL_KEYS_WIN_D;
+    private final String ACTION_SEND_SPECIAL_KEYS_WIN_G;
+
+    private static class MenuOption {
+        private final String label;
+        private final Runnable runnable;
+
+        MenuOption(String label, Runnable runnable) {
+            this.label = label;
+            this.runnable = runnable;
+        }
+    }
+
+
+    private final Game game;
+    private final NvConnection conn;
+
+    public GameBackMenu(Game game, NvConnection conn) {
+        this.game = game;
+        this.conn = conn;
+
+        this.ACTION_SEND_SPECIAL_KEYS = getString(R.string.back_menu_send_keys);
+        this.ACTION_DISCONNECT = getString(R.string.back_menu_disconnect);
+        this.ACTION_CANCEL = getString(R.string.back_menu_cancel);
+
+        this.ACTION_SEND_SPECIAL_KEYS_ESC = getString(R.string.back_menu_send_keys_esc);
+        this.ACTION_SEND_SPECIAL_KEYS_F11 = getString(R.string.back_menu_send_keys_f11);
+        this.ACTION_SEND_SPECIAL_KEYS_WIN = getString(R.string.back_menu_send_keys_win);
+        this.ACTION_SEND_SPECIAL_KEYS_WIN_D = getString(R.string.back_menu_send_keys_win_d);
+        this.ACTION_SEND_SPECIAL_KEYS_WIN_G = getString(R.string.back_menu_send_keys_win_g);
+
+        showBackMenu();
+    }
+
+    private String getString(int id) {
+        return game.getResources().getString(id);
+    }
+
+    private void sendKeySequence(byte modifier, short[] keys) {
+        for (short key : keys)
+            conn.sendKeyboardInput(key, KeyboardPacket.KEY_DOWN,
+                    (byte) (modifier | KeyboardPacket.KEY_DOWN));
+
+        for (int pos = keys.length - 1; pos >= 0; pos--)
+            conn.sendKeyboardInput(keys[pos], KeyboardPacket.KEY_UP,
+                    (byte) (modifier | KeyboardPacket.KEY_UP));
+    }
+
+    private void showMenuDialog(String title, MenuOption[] options) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(game);
+        builder.setTitle(title);
+
+        final ArrayAdapter<String> actions =
+                new ArrayAdapter<String>(game, android.R.layout.simple_list_item_1);
+
+        for (MenuOption option : options) {
+            actions.add(option.label);
+        }
+
+        builder.setAdapter(actions, (dialog, which) -> {
+            String label = actions.getItem(which);
+            for (MenuOption option : options) {
+                if (!label.equals(option.label)) {
+                    continue;
+                }
+
+                if (option.runnable != null) {
+                    option.runnable.run();
+                }
+                break;
+            }
+        });
+
+        builder.show();
+    }
+
+    private void showSpecialKeysMenu() {
+        showMenuDialog(ACTION_SEND_SPECIAL_KEYS, new MenuOption[]{
+                new MenuOption(ACTION_SEND_SPECIAL_KEYS_ESC, () -> sendKeySequence(
+                        (byte) 0, new short[]{0x18})),
+                new MenuOption(ACTION_SEND_SPECIAL_KEYS_F11, () -> sendKeySequence(
+                        (byte) 0, new short[]{0x7a})),
+                new MenuOption(ACTION_SEND_SPECIAL_KEYS_WIN, () -> sendKeySequence(
+                        (byte) 0, new short[]{0x5B})),
+                new MenuOption(ACTION_SEND_SPECIAL_KEYS_WIN_D, () -> sendKeySequence(
+                        (byte) 0, new short[]{0x5B, 0x44})),
+                new MenuOption(ACTION_SEND_SPECIAL_KEYS_WIN_G, () -> sendKeySequence(
+                        (byte) 0, new short[]{0x5B, 0x47})),
+                /*
+                TODO: Currently not working
+                new MenuDialogOption(ACTION_SEND_SPECIAL_KEYS_SHIFT_TAB, () -> sendKeySequence(
+                        (byte) 0, new short[]{0xA0, 0x09})),
+                */
+                new MenuOption(ACTION_CANCEL, null),
+        });
+    }
+
+    private void showBackMenu() {
+        showMenuDialog("Back Menu", new MenuOption[]{
+                new MenuOption(ACTION_SEND_SPECIAL_KEYS, () -> showSpecialKeysMenu()),
+                new MenuOption(ACTION_DISCONNECT, () -> game.onBackPressed()),
+                new MenuOption(ACTION_CANCEL, null),
+        });
+    }
+}

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -174,6 +174,7 @@ public class GameMenu {
             options.addAll(device.getGameMenuOptions());
         }
 
+        options.add(new MenuOption(getString(R.string.game_menu_toggle_performance_overlay), () -> game.togglePerformanceOverlay()));
         options.add(new MenuOption(getString(R.string.game_menu_send_keys), () -> showSpecialKeysMenu()));
         options.add(new MenuOption(getString(R.string.game_menu_disconnect), () -> game.disconnect()));
         options.add(new MenuOption(getString(R.string.game_menu_cancel), null));

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -144,7 +144,7 @@ public class GameMenu {
         }
 
         options.add(new MenuOption(getString(R.string.game_menu_send_keys), () -> showSpecialKeysMenu()));
-        options.add(new MenuOption(getString(R.string.game_menu_disconnect), () -> game.onBackPressed()));
+        options.add(new MenuOption(getString(R.string.game_menu_disconnect), () -> game.disconnect()));
         options.add(new MenuOption(getString(R.string.game_menu_cancel), null));
 
         showMenuDialog("Game Menu", options.toArray(new MenuOption[options.size()]));

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -90,6 +90,8 @@ public class GameMenu {
                         () -> sendKeys(new short[]{KeyboardTranslator.VK_ESCAPE})),
                 new MenuOption(getString(R.string.game_menu_send_keys_f11),
                         () -> sendKeys(new short[]{KeyboardTranslator.VK_F11})),
+                new MenuOption(getString(R.string.game_menu_send_keys_ctrl_v),
+                        () -> sendKeys(new short[]{KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_V})),
                 new MenuOption(getString(R.string.game_menu_send_keys_win),
                         () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN})),
                 new MenuOption(getString(R.string.game_menu_send_keys_win_d),

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -6,7 +6,12 @@ import android.widget.ArrayAdapter;
 import com.limelight.nvstream.NvConnection;
 import com.limelight.nvstream.input.KeyboardPacket;
 
-public class GameBackMenu {
+/**
+ * Provide options for ongoing Game Stream.
+ *
+ * Shown on back action in game activity.
+ */
+public class GameMenu {
 
     private final String ACTION_SEND_SPECIAL_KEYS;
     private final String ACTION_DISCONNECT;
@@ -32,7 +37,7 @@ public class GameBackMenu {
     private final Game game;
     private final NvConnection conn;
 
-    public GameBackMenu(Game game, NvConnection conn) {
+    public GameMenu(Game game, NvConnection conn) {
         this.game = game;
         this.conn = conn;
 
@@ -46,7 +51,7 @@ public class GameBackMenu {
         this.ACTION_SEND_SPECIAL_KEYS_WIN_D = getString(R.string.back_menu_send_keys_win_d);
         this.ACTION_SEND_SPECIAL_KEYS_WIN_G = getString(R.string.back_menu_send_keys_win_g);
 
-        showBackMenu();
+        showMenu();
     }
 
     private String getString(int id) {
@@ -112,8 +117,8 @@ public class GameBackMenu {
         });
     }
 
-    private void showBackMenu() {
-        showMenuDialog("Back Menu", new MenuOption[]{
+    private void showMenu() {
+        showMenuDialog("Game Menu", new MenuOption[]{
                 new MenuOption(ACTION_SEND_SPECIAL_KEYS, () -> showSpecialKeysMenu()),
                 new MenuOption(ACTION_DISCONNECT, () -> game.onBackPressed()),
                 new MenuOption(ACTION_CANCEL, null),

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -13,16 +13,6 @@ import com.limelight.nvstream.input.KeyboardPacket;
  */
 public class GameMenu {
 
-    private final String ACTION_SEND_SPECIAL_KEYS;
-    private final String ACTION_DISCONNECT;
-    private final String ACTION_CANCEL;
-
-    private final String ACTION_SEND_SPECIAL_KEYS_ESC;
-    private final String ACTION_SEND_SPECIAL_KEYS_F11;
-    private final String ACTION_SEND_SPECIAL_KEYS_WIN;
-    private final String ACTION_SEND_SPECIAL_KEYS_WIN_D;
-    private final String ACTION_SEND_SPECIAL_KEYS_WIN_G;
-
     private static class MenuOption {
         private final String label;
         private final Runnable runnable;
@@ -33,23 +23,12 @@ public class GameMenu {
         }
     }
 
-
     private final Game game;
     private final NvConnection conn;
 
     public GameMenu(Game game, NvConnection conn) {
         this.game = game;
         this.conn = conn;
-
-        this.ACTION_SEND_SPECIAL_KEYS = getString(R.string.back_menu_send_keys);
-        this.ACTION_DISCONNECT = getString(R.string.back_menu_disconnect);
-        this.ACTION_CANCEL = getString(R.string.back_menu_cancel);
-
-        this.ACTION_SEND_SPECIAL_KEYS_ESC = getString(R.string.back_menu_send_keys_esc);
-        this.ACTION_SEND_SPECIAL_KEYS_F11 = getString(R.string.back_menu_send_keys_f11);
-        this.ACTION_SEND_SPECIAL_KEYS_WIN = getString(R.string.back_menu_send_keys_win);
-        this.ACTION_SEND_SPECIAL_KEYS_WIN_D = getString(R.string.back_menu_send_keys_win_d);
-        this.ACTION_SEND_SPECIAL_KEYS_WIN_G = getString(R.string.back_menu_send_keys_win_g);
 
         showMenu();
     }
@@ -97,31 +76,31 @@ public class GameMenu {
     }
 
     private void showSpecialKeysMenu() {
-        showMenuDialog(ACTION_SEND_SPECIAL_KEYS, new MenuOption[]{
-                new MenuOption(ACTION_SEND_SPECIAL_KEYS_ESC, () -> sendKeySequence(
+        showMenuDialog(getString(R.string.game_menu_send_keys), new MenuOption[]{
+                new MenuOption(getString(R.string.game_menu_send_keys_esc), () -> sendKeySequence(
                         (byte) 0, new short[]{0x18})),
-                new MenuOption(ACTION_SEND_SPECIAL_KEYS_F11, () -> sendKeySequence(
+                new MenuOption(getString(R.string.game_menu_send_keys_f11), () -> sendKeySequence(
                         (byte) 0, new short[]{0x7a})),
-                new MenuOption(ACTION_SEND_SPECIAL_KEYS_WIN, () -> sendKeySequence(
+                new MenuOption(getString(R.string.game_menu_send_keys_win), () -> sendKeySequence(
                         (byte) 0, new short[]{0x5B})),
-                new MenuOption(ACTION_SEND_SPECIAL_KEYS_WIN_D, () -> sendKeySequence(
+                new MenuOption(getString(R.string.game_menu_send_keys_win_d), () -> sendKeySequence(
                         (byte) 0, new short[]{0x5B, 0x44})),
-                new MenuOption(ACTION_SEND_SPECIAL_KEYS_WIN_G, () -> sendKeySequence(
+                new MenuOption(getString(R.string.game_menu_send_keys_win_g), () -> sendKeySequence(
                         (byte) 0, new short[]{0x5B, 0x47})),
                 /*
-                TODO: Currently not working
-                new MenuDialogOption(ACTION_SEND_SPECIAL_KEYS_SHIFT_TAB, () -> sendKeySequence(
+                // TODO: Currently not working
+                new MenuDialogOption(getString(R.string.game_menu_send_keys_shift_tab), () -> sendKeySequence(
                         (byte) 0, new short[]{0xA0, 0x09})),
                 */
-                new MenuOption(ACTION_CANCEL, null),
+                new MenuOption(getString(R.string.game_menu_cancel), null),
         });
     }
 
     private void showMenu() {
         showMenuDialog("Game Menu", new MenuOption[]{
-                new MenuOption(ACTION_SEND_SPECIAL_KEYS, () -> showSpecialKeysMenu()),
-                new MenuOption(ACTION_DISCONNECT, () -> game.onBackPressed()),
-                new MenuOption(ACTION_CANCEL, null),
+                new MenuOption(getString(R.string.game_menu_send_keys), () -> showSpecialKeysMenu()),
+                new MenuOption(getString(R.string.game_menu_disconnect), () -> game.onBackPressed()),
+                new MenuOption(getString(R.string.game_menu_cancel), null),
         });
     }
 }

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -65,7 +65,7 @@ public class GameMenu {
         final byte[] modifier = {(byte) 0};
 
         for (short key : keys) {
-            conn.sendKeyboardInput(key, KeyboardPacket.KEY_DOWN, modifier[0]);
+            conn.sendKeyboardInput(key, KeyboardPacket.KEY_DOWN, modifier[0], (byte) 0);
 
             // Apply the modifier of the pressed key, e.g. CTRL first issues a CTRL event (without
             // modifier) and then sends the following keys with the CTRL modifier applied
@@ -80,7 +80,7 @@ public class GameMenu {
                 // Remove the keys modifier before releasing the key
                 modifier[0] &= ~getModifier(key);
 
-                conn.sendKeyboardInput(key, KeyboardPacket.KEY_UP, modifier[0]);
+                conn.sendKeyboardInput(key, KeyboardPacket.KEY_UP, modifier[0], (byte) 0);
             }
         }), KEY_UP_DELAY);
     }

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -4,9 +4,13 @@ import android.app.AlertDialog;
 import android.os.Handler;
 import android.widget.ArrayAdapter;
 
+import com.limelight.binding.input.GameInputDevice;
 import com.limelight.binding.input.KeyboardTranslator;
 import com.limelight.nvstream.NvConnection;
 import com.limelight.nvstream.input.KeyboardPacket;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Provide options for ongoing Game Stream.
@@ -17,11 +21,11 @@ public class GameMenu {
 
     private static final long KEY_UP_DELAY = 25;
 
-    private static class MenuOption {
+    public static class MenuOption {
         private final String label;
         private final Runnable runnable;
 
-        MenuOption(String label, Runnable runnable) {
+        public MenuOption(String label, Runnable runnable) {
             this.label = label;
             this.runnable = runnable;
         }
@@ -29,10 +33,12 @@ public class GameMenu {
 
     private final Game game;
     private final NvConnection conn;
+    private final GameInputDevice device;
 
-    public GameMenu(Game game, NvConnection conn) {
+    public GameMenu(Game game, NvConnection conn, GameInputDevice device) {
         this.game = game;
         this.conn = conn;
+        this.device = device;
 
         showMenu();
     }
@@ -128,10 +134,19 @@ public class GameMenu {
     }
 
     private void showMenu() {
-        showMenuDialog("Game Menu", new MenuOption[]{
-                new MenuOption(getString(R.string.game_menu_send_keys), () -> showSpecialKeysMenu()),
-                new MenuOption(getString(R.string.game_menu_disconnect), () -> game.onBackPressed()),
-                new MenuOption(getString(R.string.game_menu_cancel), null),
-        });
+        List<MenuOption> options = new ArrayList<>();
+
+        options.add(new MenuOption(getString(R.string.game_menu_toggle_keyboard),
+                () -> game.toggleKeyboard()));
+
+        if (device != null) {
+            options.addAll(device.getGameMenuOptions());
+        }
+
+        options.add(new MenuOption(getString(R.string.game_menu_send_keys), () -> showSpecialKeysMenu()));
+        options.add(new MenuOption(getString(R.string.game_menu_disconnect), () -> game.onBackPressed()));
+        options.add(new MenuOption(getString(R.string.game_menu_cancel), null));
+
+        showMenuDialog("Game Menu", options.toArray(new MenuOption[options.size()]));
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -22,7 +22,9 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.widget.Toast;
 
+import com.limelight.GameMenu;
 import com.limelight.LimeLog;
+import com.limelight.R;
 import com.limelight.binding.input.driver.AbstractController;
 import com.limelight.binding.input.driver.UsbDriverListener;
 import com.limelight.binding.input.driver.UsbDriverService;
@@ -36,6 +38,8 @@ import com.limelight.utils.Vector2d;
 import org.cgutman.shieldcontrollerextensions.SceManager;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ControllerHandler implements InputManager.InputDeviceListener, UsbDriverListener {
 
@@ -1521,7 +1525,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             if ((context.inputMap & ControllerPacket.PLAY_FLAG) != 0 &&
                     event.getEventTime() - context.startDownTime > ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS &&
                     prefConfig.mouseEmulation) {
-                context.toggleMouseEmulation();
+                gestures.showGameMenu(context);
             }
             context.inputMap &= ~ControllerPacket.PLAY_FLAG;
             break;
@@ -1868,7 +1872,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         usbDeviceContexts.put(controller.getControllerId(), context);
     }
 
-    class GenericControllerContext {
+    class GenericControllerContext implements GameInputDevice {
         public int id;
         public boolean external;
 
@@ -1910,6 +1914,16 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                 handler.postDelayed(this, mouseEmulationReportPeriod);
             }
         };
+
+        @Override
+        public List<GameMenu.MenuOption> getGameMenuOptions() {
+            List<GameMenu.MenuOption> options = new ArrayList<>();
+            options.add(new GameMenu.MenuOption(activityContext.getString(mouseEmulationActive ?
+                    R.string.game_menu_toggle_mouse_off : R.string.game_menu_toggle_mouse_on),
+                    () -> toggleMouseEmulation()));
+
+            return options;
+        }
 
         public void toggleMouseEmulation() {
             handler.removeCallbacks(mouseEmulationRunnable);

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -1920,7 +1920,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             List<GameMenu.MenuOption> options = new ArrayList<>();
             options.add(new GameMenu.MenuOption(activityContext.getString(mouseEmulationActive ?
                     R.string.game_menu_toggle_mouse_off : R.string.game_menu_toggle_mouse_on),
-                    () -> toggleMouseEmulation()));
+                    true, () -> toggleMouseEmulation()));
 
             return options;
         }

--- a/app/src/main/java/com/limelight/binding/input/GameInputDevice.java
+++ b/app/src/main/java/com/limelight/binding/input/GameInputDevice.java
@@ -1,0 +1,16 @@
+package com.limelight.binding.input;
+
+import com.limelight.GameMenu;
+
+import java.util.List;
+
+/**
+ * Generic Input Device
+ */
+public interface GameInputDevice {
+
+    /**
+     * @return list of device specific game menu options, e.g. configure a controller's mouse mode
+     */
+    List<GameMenu.MenuOption> getGameMenuOptions();
+}

--- a/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.java
+++ b/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.java
@@ -24,6 +24,8 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
     public static final int VK_0 = 48;
     public static final int VK_9 = 57;
     public static final int VK_A = 65;
+    public static final int VK_D = 68;
+    public static final int VK_G = 71;
     public static final int VK_Z = 90;
     public static final int VK_NUMPAD0 = 96;
     public static final int VK_BACK_SLASH = 92;
@@ -34,6 +36,7 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
     public static final int VK_EQUALS = 61;
     public static final int VK_ESCAPE = 27;
     public static final int VK_F1 = 112;
+    public static final int VK_F11 = 122;
     public static final int VK_END = 35;
     public static final int VK_HOME = 36;
     public static final int VK_NUM_LOCK = 144;
@@ -54,6 +57,8 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
     public static final int VK_BACK_QUOTE = 192;
     public static final int VK_QUOTE = 222;
     public static final int VK_PAUSE = 19;
+    public static final int VK_LWIN = 91;
+    public static final int VK_LSHIFT = 160;
 
     private static class KeyboardMapping {
         private final InputDevice device;
@@ -225,7 +230,7 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
                 break;
 
             case KeyEvent.KEYCODE_META_LEFT:
-                translated = 0x5b;
+                translated = VK_LWIN;
                 break;
 
             case KeyEvent.KEYCODE_META_RIGHT:
@@ -273,7 +278,7 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
                 break;
                 
             case KeyEvent.KEYCODE_SHIFT_LEFT:
-                translated = 0xA0;
+                translated = VK_LSHIFT;
                 break;
 
             case KeyEvent.KEYCODE_SHIFT_RIGHT:

--- a/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.java
+++ b/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.java
@@ -24,8 +24,10 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
     public static final int VK_0 = 48;
     public static final int VK_9 = 57;
     public static final int VK_A = 65;
+    public static final int VK_C = 67;
     public static final int VK_D = 68;
     public static final int VK_G = 71;
+    public static final int VK_V = 86;
     public static final int VK_Z = 90;
     public static final int VK_NUMPAD0 = 96;
     public static final int VK_BACK_SLASH = 92;
@@ -59,6 +61,7 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
     public static final int VK_PAUSE = 19;
     public static final int VK_LWIN = 91;
     public static final int VK_LSHIFT = 160;
+    public static final int VK_LCONTROL = 162;
 
     private static class KeyboardMapping {
         private final InputDevice device;
@@ -193,7 +196,7 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
                 break;
                 
             case KeyEvent.KEYCODE_CTRL_LEFT:
-                translated = 0xA2;
+                translated = VK_LCONTROL;
                 break;
 
             case KeyEvent.KEYCODE_CTRL_RIGHT:

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -1305,7 +1305,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
         // Flip stats windows roughly every second
         if (SystemClock.uptimeMillis() >= activeWindowVideoStats.measurementStartTimestamp + 1000) {
-            if (prefs.enablePerfOverlay) {
+            if (perfListener.isPerfOverlayVisible()) {
                 VideoStats lastTwo = new VideoStats();
                 lastTwo.add(lastWindowVideoStats);
                 lastTwo.add(activeWindowVideoStats);

--- a/app/src/main/java/com/limelight/binding/video/PerfOverlayListener.java
+++ b/app/src/main/java/com/limelight/binding/video/PerfOverlayListener.java
@@ -2,4 +2,5 @@ package com.limelight.binding.video;
 
 public interface PerfOverlayListener {
     void onPerfUpdate(final String text);
+    boolean isPerfOverlayVisible();
 }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -34,7 +34,6 @@ public class PreferenceConfiguration {
     private static final String LEGACY_DISABLE_FRAME_DROP_PREF_STRING = "checkbox_disable_frame_drop";
     private static final String ENABLE_HDR_PREF_STRING = "checkbox_enable_hdr";
     private static final String ENABLE_PIP_PREF_STRING = "checkbox_enable_pip";
-    private static final String ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay";
     private static final String BIND_ALL_USB_STRING = "checkbox_usb_bind_all";
     private static final String MOUSE_EMULATION_STRING = "checkbox_mouse_emulation";
     private static final String MOUSE_NAV_BUTTONS_STRING = "checkbox_mouse_nav_buttons";
@@ -66,7 +65,6 @@ public class PreferenceConfiguration {
     private static final boolean ONLY_L3_R3_DEFAULT = false;
     private static final boolean DEFAULT_ENABLE_HDR = false;
     private static final boolean DEFAULT_ENABLE_PIP = false;
-    private static final boolean DEFAULT_ENABLE_PERF_OVERLAY = false;
     private static final boolean DEFAULT_BIND_ALL_USB = false;
     private static final boolean DEFAULT_MOUSE_EMULATION = true;
     private static final boolean DEFAULT_MOUSE_NAV_BUTTONS = false;
@@ -112,7 +110,6 @@ public class PreferenceConfiguration {
     public boolean onlyL3R3;
     public boolean enableHdr;
     public boolean enablePip;
-    public boolean enablePerfOverlay;
     public boolean enableLatencyToast;
     public boolean bindAllUsb;
     public boolean mouseEmulation;
@@ -496,7 +493,6 @@ public class PreferenceConfiguration {
         config.onlyL3R3 = prefs.getBoolean(ONLY_L3_R3_PREF_STRING, ONLY_L3_R3_DEFAULT);
         config.enableHdr = prefs.getBoolean(ENABLE_HDR_PREF_STRING, DEFAULT_ENABLE_HDR) && !isShieldAtvFirmwareWithBrokenHdr();
         config.enablePip = prefs.getBoolean(ENABLE_PIP_PREF_STRING, DEFAULT_ENABLE_PIP);
-        config.enablePerfOverlay = prefs.getBoolean(ENABLE_PERF_OVERLAY_STRING, DEFAULT_ENABLE_PERF_OVERLAY);
         config.bindAllUsb = prefs.getBoolean(BIND_ALL_USB_STRING, DEFAULT_BIND_ALL_USB);
         config.mouseEmulation = prefs.getBoolean(MOUSE_EMULATION_STRING, DEFAULT_MOUSE_EMULATION);
         config.mouseNavButtons = prefs.getBoolean(MOUSE_NAV_BUTTONS_STRING, DEFAULT_MOUSE_NAV_BUTTONS);

--- a/app/src/main/java/com/limelight/ui/GameGestures.java
+++ b/app/src/main/java/com/limelight/ui/GameGestures.java
@@ -1,5 +1,9 @@
 package com.limelight.ui;
 
+import com.limelight.binding.input.GameInputDevice;
+
 public interface GameGestures {
     void toggleKeyboard();
+
+    void showGameMenu(GameInputDevice device);
 }

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -90,8 +90,6 @@
     <string name="category_help">Nápověda</string>
     <string name="summary_checkbox_disable_warnings">Zakáže varování o pomalém připojení během streamování</string>
     <string name="title_disable_frame_drop">Nezahazovat snímky</string>
-    <string name="title_enable_perf_overlay">Zobrazit během streamování informace o výkonu</string>
-    <string name="summary_enable_perf_overlay">Zobrazit realtime informace o výkonu streamu během streamování</string>
     <string name="resolution_4k">4K</string>
     <string name="fps_30">30 FPS</string>
     <string name="title_troubleshooting">Průvodce řešením problémů</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -195,8 +195,6 @@
     <string name="summary_video_format">HEVC verringert die Video-Bandbreitenanforderung, funktioniert allerdings nur auf sehr neuen Geräten</string>
     <string name="title_enable_hdr">HDR aktivieren (experimentell)</string>
     <string name="summary_enable_hdr">HDR-Streaming sofern dies von der Host-GPU unterstützt wird. HDR erfordert eine GPU der GTX 1000 Serie oder neuer.</string>
-    <string name="title_enable_perf_overlay">Performance Overlay aktivieren</string>
-    <string name="summary_enable_perf_overlay">Leistungsmerkmale während des Streamens in Echtzeit einblenden</string>
     <string name="title_enable_post_stream_toast">Zeige Latenz-Informationen nach dem Streaming</string>
     <string name="summary_enable_post_stream_toast">Anzeige einer Informationsmeldung über die Latenz nach dem Ende des Streams</string>
     <string name="resolution_prefix_native">Nativ</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -44,7 +44,6 @@
     <string name="applist_quit_fail">Αποτυχία διακοπής</string>
     <string name="applist_quit_confirmation">Είστε σίγουροι ότι θέλετε να τερματίσετε την τρέχουσα εφαρμογή; Όλα τα μη αποθηκευμένα δεδομένα θα χαθούν.</string>
     <string name="dialog_text_reset_osc">Είστε βέβαιοι ότι θέλετε να διαγράψετε την αποθηκευμένη διάταξη στοιχείων ελέγχου στην οθόνη;</string>
-    <string name="title_enable_perf_overlay">Εμφάνιση στατιστικών στοιχείων απόδοσης κατά τη ροή</string>
     <string name="unpair_error">Η συσκευή δεν είχε συζευξηθεί</string>
     <string name="error_pc_offline">Ο υπολογιστής είναι εκτός σύνδεσης</string>
     <string name="error_unknown_host">Αποτυχία επίλυσης ονόματος κεντρικού υπολογιστή</string>
@@ -130,7 +129,6 @@
     <string name="summary_disable_frame_drop">Μπορεί να μειώσει το micro-stuttering σε ορισμένες συσκευές, αλλά μπορεί να αυξήσει την καθυστέρηση</string>
     <string name="title_enable_hdr">Ενεργοποίηση HDR (πειραματικό)</string>
     <string name="summary_enable_hdr">Μεταδώστε HDR όταν το παιχνίδι και η GPU του υπολογιστή το υποστηρίζουν. Το HDR απαιτεί GPU της σειράς GTX 1000 ή νεότερη.</string>
-    <string name="summary_enable_perf_overlay">Εμφάνιση πληροφοριών απόδοσης ροής σε πραγματικό χρόνο κατά τη ροή</string>
     <string name="summary_enable_post_stream_toast">Εμφάνιση ενός μηνύματος πληροφοριών καθυστέρησης μετά το τέλος της ροής</string>
     <string name="scut_deleted_pc">Ο υπολογιστής διαγράφηκε</string>
     <string name="scut_pc_not_found">Ο υπολογιστής δεν βρέθηκε</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -209,7 +209,6 @@
     <string name="title_checkbox_mouse_nav_buttons">Activar los botones atrás y adelante del ratón</string>
     <string name="title_unlock_fps">Desbloquear todas las opciones de tasa de cuadros disponibles</string>
     <string name="summary_unlock_fps">Transmitir a 90 o 120 FPS puede reducir latencia en dispositivos de gama alta pero puede causar retrasos en dispositivos que no lo soporten</string>
-    <string name="title_enable_perf_overlay">Mostrar estadísticas de rendimiento mientras la transmisión está activa</string>
     <string name="summary_enable_post_stream_toast">Mostrar un mensaje sobre la información de latencia cuando la transmisión termine</string>
     <string name="help">Ayuda</string>
     <string name="delete_pc_msg">¿Estás seguro de eliminar este PC\?</string>
@@ -243,7 +242,6 @@
     <string name="summary_disable_frame_drop">Puede reducir micro-tartamudeos (Stuttering) en algunos dispositivos , pero puede incrementar latencia</string>
     <string name="title_enable_hdr">Activar HDR (Alto Rango Dinámico / Experimental)</string>
     <string name="summary_enable_hdr">Transmite en HDR cuando el juego y la GPU del PC lo admitan. HDR requiere una GPU compatible con la codificación HEVC Main 10.</string>
-    <string name="summary_enable_perf_overlay">Mostrar en tiempo real la información del desempeño de la transmisión mientras está activa la misma</string>
     <string name="title_enable_post_stream_toast">Mostrar mensajes sobre latencia mientras se transmite</string>
     <string name="category_help">Ayuda</string>
     <string name="title_setup_guide">Guía para la Configuración</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -189,8 +189,6 @@
     <string name="summary_video_format">HEVC réduit les besoins en bande passante vidéo mais nécessite un périphérique très récent</string>
     <string name="title_enable_hdr">Activer le HDR (expérimental)</string>
     <string name="summary_enable_hdr">Diffuser du HDR lorsque le jeu et le processeur graphique du PC le prennent en charge. HDR nécessite un GPU série GTX 1000 ou une version ultérieure.</string>
-    <string name="title_enable_perf_overlay">Activer la superposition de performance</string>
-    <string name="summary_enable_perf_overlay">Afficher une superposition à l\'écran avec des informations de performance en temps réel pendant la lecture en continu</string>
     <string name="title_enable_post_stream_toast">Afficher le message de latence après la diffusion en continu</string>
     <string name="summary_enable_post_stream_toast">Afficher un message d’informations de latence après la fin du flux</string>
     <string name="no_video_received_error">Aucune vidéo reçue depuis l\'hôte.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <string name="summary_enable_post_stream_toast">Késleltetési információs üzenet megjelenítése az adatfolyam vége után</string>
     <string name="title_enable_post_stream_toast">A késleltetési üzenet megjelenítése streaming után</string>
-    <string name="summary_enable_perf_overlay">Valós idejű adatfolyam-adat megjelenítése streaming közben</string>
-    <string name="title_enable_perf_overlay">Teljesítmény statisztikák megjelenítése közvetítés közben</string>
     <string name="summary_enable_hdr">Streaming HDR, amikor a játék és a PC GPU támogatja. A HDR-hez GTX 1000 sorozatú vagy újabb verzió szükséges.</string>
     <string name="title_enable_hdr">HDR engedélyezése (kísérleti)</string>
     <string name="summary_video_format">A HEVC csökkenti a video sávszélesség követelményeit, de újabb eszközt igényel</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -213,7 +213,6 @@
     <string name="videoformat_hevcnever">Non usare mai HEVC</string>
     <string name="title_frame_pacing">Bilanciamento frame video</string>
     <string name="summary_frame_pacing">Specifica come bilanciare il ritardo video e la fluidità</string>
-    <string name="summary_enable_perf_overlay">Mostra informazioni real time sulla trasmissione</string>
     <string name="nettest_text_failure">Sembra che l\'attuale connessione di rete del tuo dispositivo stia bloccando Moonlight. Trasmettere via Internet potrebbe non funzionare mentre sei connesso a questa rete.
 \n
 \nQueste porte di rete sono bloccate:
@@ -222,7 +221,6 @@
     <string name="unable_to_pin_shortcut">Il tuo launcher non permette la creazione di scorciatoie appuntate.</string>
     <string name="video_decoder_init_failed">Il decoder video non è riuscito ad inizializzarsi. Il tuo dispositivo potrebbe non supportare la risoluzione o il frame rate selezionati.</string>
     <string name="check_ports_msg">Controlla il tuo firewall e le regole di inoltro delle seguenti porte:</string>
-    <string name="title_enable_perf_overlay">Mostra le statistiche delle performance durante la trasmissione</string>
     <string name="title_enable_post_stream_toast">Mostra un messaggio sulla latenza dopo la trasmissione</string>
     <string name="no_frame_received_error">La tua connessione di rete non sta funzionando bene. Riduci il bitrate video o prova ad usare una connessione più veloce.</string>
     <string name="early_termination_error">Qualcosa è andato storto sul PC sorgente mentre la trasmissione veniva avviata.

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -188,8 +188,6 @@
     <string name="scut_invalid_app_id">앱을 사용할 수 없음</string>
     <string name="summary_enable_post_stream_toast">스트림 종료 후 지연시간 정보 표시</string>
     <string name="title_enable_post_stream_toast">스트리밍 후 지연시간 정보 표시</string>
-    <string name="title_enable_perf_overlay">스트리밍 중 성능 정보 표시</string>
-    <string name="summary_enable_perf_overlay">스트리밍하는 동안 실시간 스트림 성능 정보 표시</string>
     <string name="summary_enable_hdr">게임 및 PC의 GPU가 HDR을 지원하는 경우 HDR을 활성화합니다. HDR에는 GTX 1000 시리즈 또는 그 이상의 GPU가 필요합니다.</string>
     <string name="title_enable_hdr">HDR활성화 (실험용)</string>
     <string name="summary_disable_frame_drop">일부 장치에서 미세한 끊김 현상을 줄일 수 있지만 지연 시간이 늘어날 수 있습니다.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -143,8 +143,6 @@
 \nFølgende nettverksporter ble blokkert:
 \n</string>
     <string name="nettest_text_inconclusive">Nettverkstesten kunne ikke utføres fordi ingen av Moonlight sine tilkoblingstesttjenere kunne nås. Sjekk din tilkobling til Internett og prøv igjen senere.</string>
-    <string name="summary_enable_perf_overlay">Viser ytelsesinfo i sanntid under strømming</string>
-    <string name="title_enable_perf_overlay">Vis ytelsesstatistikk under strømming</string>
     <string name="summary_enable_hdr">Strøm HDR når spillet og PC-ens skjermkort støtter det. HDR krever GTX 1000-eller nyere.</string>
     <string name="summary_checkbox_enable_pip">Tillater strømmen å vises (men ikke kontrolleres) under fleroppgaveløsning</string>
     <string name="title_checkbox_enable_pip">Skru på bilde-i-bilde-observatørmodus</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -174,7 +174,6 @@
     <string name="summary_disable_frame_drop">Kan micro-stotteren op sommige toestellen verminderen, maar kan vertraging verhogen</string>
     <string name="title_enable_hdr">HDR Inschakelen (Experimenteel)</string>
     <string name="summary_enable_hdr">Stream HDR als het spel en de GPU van de PC dit ondersteund. HDR vereist een GTX 1000-reeks GPU of later.</string>
-    <string name="title_enable_perf_overlay">Prestatiestatistieken tonen tijdens het streamen</string>
     <string name="title_details">Details</string>
     <string name="delete_pc_msg">Bent u zeker dat u deze PC wilt verwijderen\?</string>
     <string name="resolution_prefix_native_fullscreen">Oorspronkelijk Volledig Scherm</string>
@@ -201,7 +200,6 @@
     <string name="summary_checkbox_touchscreen_trackpad">Wanneer ingeschakeld functioneert het touchscreen als een trackpad. Wanneer uitgeschakeld bedient het touchscreen rechtstreeks de muiscursor.</string>
     <string name="summary_checkbox_usb_bind_all">Gebruik Moonlight\'s USB driver voor alle ondersteunde gamepads, zelfs als een standaard Xbox controller aanwezig is</string>
     <string name="dialog_text_reset_osc">Bent u zeker dat u uw opgeslagen on-screen controle-elementen wilt verwijderen\?</string>
-    <string name="summary_enable_perf_overlay">Real-time prestatie-informatie tonen tijdens het streamen</string>
     <string name="title_checkbox_vibrate_fallback">Simuleer rumble-ondersteuning met trillingen</string>
     <string name="summary_checkbox_mouse_nav_buttons">Deze optie inschakelen kan problemen veroorzaken met rechts-klikken op sommige buggy apparaten</string>
     <string name="summary_checkbox_vibrate_fallback">Laat uw apparaat trillen om gerommel te simuleren als uw gamepad dit niet ondersteund</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -226,8 +226,6 @@
     <string name="summary_disable_frame_drop">Talvez reduza o micro-stuttering em alguns dispositivos, mas pode aumentar a latência</string>
     <string name="title_enable_hdr">Habilitar HDR (Experimental)</string>
     <string name="title_enable_post_stream_toast">Mostrar aviso de latência após terminar a transmissão</string>
-    <string name="summary_enable_perf_overlay">Exibe informações de performance em tempo real durante a transmissão</string>
-    <string name="title_enable_perf_overlay">Mostrar status de performance durante a transmissão</string>
     <string name="category_help">Ajuda</string>
     <string name="title_troubleshooting">Guia de solução de problemas</string>
     <string name="title_setup_guide">Guia de configuração</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -117,7 +117,6 @@
     <string name="title_enable_hdr">Ativar HDR (Experimental)</string>
     <string name="summary_full_range">Isso causará perda de detalhes em áreas claras e escuras se o seu aparelho não exibir corretamente todo o conteúdo de vídeo em cores.</string>
     <string name="title_disable_frame_drop">Nunca dropar quadros</string>
-    <string name="summary_enable_perf_overlay">Exibe informações de performance em tempo real durante a transmissão</string>
     <string name="title_enable_post_stream_toast">Mostrar aviso de latência após terminar a transmissão</string>
     <string name="title_troubleshooting">Guia de solução de problemas</string>
     <string name="summary_troubleshooting">Veja dicas para diagnosticar e corrigir problemas comuns de streaming</string>
@@ -209,7 +208,6 @@
     <string name="title_checkbox_disable_warnings">Desativar mensagens de alerta</string>
     <string name="title_video_format">Mudar configurações do HEVC</string>
     <string name="summary_enable_hdr">Transmita HDR quando o jogo e a GPU do PC suportarem. O HDR requer uma GPU da série GTX 1000 ou posterior.</string>
-    <string name="title_enable_perf_overlay">Mostrar status de performance durante a transmissão</string>
     <string name="nettest_title_done">Teste de Internet Completo</string>
     <string name="nettest_text_inconclusive">O teste de rede não pôde ser executado porque nenhum dos servidores de teste de conexão do Moonlight estava acessível. Verifique a sua conexão com a Internet ou tente novamente mais tarde.</string>
     <string name="pairing">A parear…</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -188,8 +188,6 @@
     <string name="summary_video_format">HEVC funcționează cu o conexiune mai slaba, dar necesită un dispozitiv recent, performant</string>
     <string name="title_enable_hdr">Activează HDR (Experimental)</string>
     <string name="summary_enable_hdr">Folosește HDR daca aplicația si placa video suportă. Necesită o placa video seria GTX 1000 sau mai nouă.</string>
-    <string name="title_enable_perf_overlay">Activează statisticile de performanță</string>
-    <string name="summary_enable_perf_overlay">Afișează în timp real statisticile de performanță ale conexiunii.</string>
 
     <!-- Array strings -->
     <string name="audioconf_stereo">Stereo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -162,7 +162,6 @@
     <string name="pcview_menu_details">Детали</string>
     <string name="poor_connection_msg">Слабое соединение с PC</string>
     <string name="title_details">Детали</string>
-    <string name="title_enable_perf_overlay">Включить отображение статистики</string>
     <string name="title_unlock_fps">Разблокировать все возможные частоты обновления</string>
     <string name="applist_details_id">ID приложения:</string>
     <string name="title_checkbox_vibrate_fallback">Эмуляция виброотдачи</string>
@@ -174,7 +173,6 @@
     <string name="title_checkbox_mouse_nav_buttons">Включить кнопки вперед и назад для мыши</string>
     <string name="slow_connection_msg">Медленное подключение к PC\nУменьшите битрейт</string>
     <string name="summary_unlock_fps">Трансляция со скоростью 90 или 120 кадров в секунду может уменьшить задержку на устройствах высокого класса, но может вызвать задержки или сбой на устройствах без поддержки этого функционала</string>
-    <string name="summary_enable_perf_overlay">Отображение оверлея на экране с информацией о производительности во время трансляции в режиме реального времени</string>
     <string name="perf_overlay_decoder">Декодер: %1$s</string>
     <string name="perf_overlay_incomingfps">Входящая частота кадров из сети: %1$.2f FPS</string>
     <string name="perf_overlay_renderingfps">Частота кадров при рендеринге: %1$.2f FPS</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -146,7 +146,6 @@
     <string name="pcview_menu_details">Деталі</string>
     <string name="poor_connection_msg">Слабке з\'єднання з пристроєм</string>
     <string name="title_details">Деталі</string>
-    <string name="title_enable_perf_overlay">Увімкнути відображення статистики</string>
     <string name="title_unlock_fps">Розблокувати всі можливі частоти кадрів</string>
     <string name="applist_details_id">ID застосунку:</string>
     <string name="title_checkbox_vibrate_fallback">Емуляція вібровіддачі</string>
@@ -161,7 +160,6 @@
     <string name="slow_connection_msg">Повільне підключення
 \nЗменшіть швидкість потоку</string>
     <string name="summary_unlock_fps">Трансляція зі швидкістю 90 або 120 кадрів на секунду може зменшити затримку на швидких пристроях але, може викликати затримки або збої на слабших</string>
-    <string name="summary_enable_perf_overlay">Відображає статистику продуктивності під час трансляції, в режимі реального часу</string>
     <string name="perf_overlay_decoder">Розцифрувач: %1$s</string>
     <string name="perf_overlay_incomingfps">Вхідна частота кадрів з мережі: %1$.2f FPS</string>
     <string name="perf_overlay_renderingfps">Частота кадрів при відтворенні: %1$.2f FPS</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <string name="summary_enable_post_stream_toast">Hiển thị một thông báo thông tin độ trễ sau khi kết thúc stream</string>
     <string name="title_enable_post_stream_toast">Hiện thông báo độ trễ sau khi stream</string>
-    <string name="summary_enable_perf_overlay">Hiển thị thông tin hiệu năng stream theo thời gian thực trong khi stream</string>
-    <string name="title_enable_perf_overlay">Hiện thống kê hiệu năng trong khi stream</string>
     <string name="summary_enable_hdr">Stream HDR khi trò chơi và GPU của PC hỗ trợ nó. HDR yêu cầu GPU GTX series 1000 hoặc mới hơn.</string>
     <string name="title_enable_hdr">Bật HDR (Thử nghiệm)</string>
     <string name="summary_video_format">HEVC làm giảm yêu cầu băng thông video nhưng yêu cầu một thiết bị mới hơn</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -169,8 +169,6 @@
     <string name="summary_video_format">HEVC能降低视频带宽需求，但需要较新的设备才能支持</string>
     <string name="title_enable_hdr">启用 HDR (实验性)</string>
     <string name="summary_enable_hdr">当游戏和显卡支持时以HDR模式串流。 HDR需要显卡支持 HEVC Main 10 编码。</string>
-    <string name="title_enable_perf_overlay"> 启用性能信息 </string>
-    <string name="summary_enable_perf_overlay"> 在串流中显示实时性能信息 </string>
     <string name="title_enable_post_stream_toast">串流完毕显示延迟信息</string>
     <string name="summary_enable_post_stream_toast">串流结束后显示延迟信息</string>
     <string name="title_osc_opacity">更改屏幕按钮透明度</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -170,8 +170,6 @@
     <string name="summary_video_format">HEVC 能降低視訊頻寬需求，但需要較新的裝置才能支援</string>
     <string name="title_enable_hdr">啟用 HDR (實驗性)</string>
     <string name="summary_enable_hdr">在遊戲和 GPU 支援時以 HDR 模式串流，HDR 模式需要支援 HEVC Main 10 編碼的 GPU。</string>
-    <string name="title_enable_perf_overlay">串流時顯示效能資訊</string>
-    <string name="summary_enable_perf_overlay">在串流中顯示即時效能資訊</string>
     <string name="title_enable_post_stream_toast">串流後顯示延時資訊</string>
     <string name="summary_enable_post_stream_toast">串流結束後顯示延時資訊</string>
     <string name="title_osc_opacity">變更螢幕控制按鈕透明度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
 
     <!-- In Game menu -->
     <string name="game_menu_toggle_keyboard">Toggle On-screen Keyboard</string>
+    <string name="game_menu_toggle_performance_overlay">Toggle Performance Overlay</string>
     <string name="game_menu_toggle_mouse_on">Enable Controller Mouse Emulation</string>
     <string name="game_menu_toggle_mouse_off">Disable Controller Mouse Emulation</string>
     <string name="game_menu_disconnect">Disconnect</string>
@@ -248,8 +249,6 @@
     <string name="summary_enable_hdr">Stream HDR when the game and PC GPU support it. HDR requires a GPU with HEVC Main 10 encoding support.</string>
     <string name="title_full_range">Force full range video (Experimental)</string>
     <string name="summary_full_range">This will cause loss of detail in light and dark areas if your device doesn\'t properly display full range video content.</string>
-    <string name="title_enable_perf_overlay">Show performance stats while streaming</string>
-    <string name="summary_enable_perf_overlay">Display real-time stream performance information while streaming</string>
     <string name="title_enable_post_stream_toast">Show latency message after streaming</string>
     <string name="summary_enable_post_stream_toast">Display a latency information message after the stream ends</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="game_menu_send_keys">Send special key(s)</string>
     <string name="game_menu_send_keys_esc">Send ESC (Menu)</string>
     <string name="game_menu_send_keys_f11">Send F11 (Toggle full screen)</string>
+    <string name="game_menu_send_keys_ctrl_v">Send CTRL + V (Paste clipboard)</string>
     <string name="game_menu_send_keys_win">Send WIN (Toggle Windows start menu)</string>
     <string name="game_menu_send_keys_win_d">Send WIN + D (Switch to Desktop)</string>
     <string name="game_menu_send_keys_win_g">Send WIN + G (Open Xbox Game Bar)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,13 +133,16 @@
     <string name="applist_details_id">App ID:</string>
 
     <!-- In Game menu -->
+    <string name="game_menu_toggle_keyboard">Toggle On-screen Keyboard</string>
+    <string name="game_menu_toggle_mouse_on">Enable Controller Mouse Emulation</string>
+    <string name="game_menu_toggle_mouse_off">Disable Controller Mouse Emulation</string>
     <string name="game_menu_disconnect">Disconnect</string>
     <string name="game_menu_cancel">Cancel</string>
-    <string name="game_menu_send_keys">Send special key(s)</string>
+    <string name="game_menu_send_keys">Send special Key(s)</string>
     <string name="game_menu_send_keys_esc">Send ESC (Menu)</string>
-    <string name="game_menu_send_keys_f11">Send F11 (Toggle full screen)</string>
-    <string name="game_menu_send_keys_ctrl_v">Send CTRL + V (Paste clipboard)</string>
-    <string name="game_menu_send_keys_win">Send WIN (Toggle Windows start menu)</string>
+    <string name="game_menu_send_keys_f11">Send F11 (Toggle Full Screen)</string>
+    <string name="game_menu_send_keys_ctrl_v">Send CTRL + V (Paste Clipboard)</string>
+    <string name="game_menu_send_keys_win">Send WIN (Toggle Windows Start Menu)</string>
     <string name="game_menu_send_keys_win_d">Send WIN + D (Switch to Desktop)</string>
     <string name="game_menu_send_keys_win_g">Send WIN + G (Open Xbox Game Bar)</string>
     <string name="game_menu_send_keys_shift_tab">Send SHIFT + TAB (Open Steam Overlay)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,16 +132,16 @@
     <string name="applist_quit_confirmation">Are you sure you want to quit the running app? All unsaved data will be lost.</string>
     <string name="applist_details_id">App ID:</string>
 
-    <!-- Game back menu -->
-    <string name="back_menu_disconnect">Disconnect</string>
-    <string name="back_menu_cancel">Cancel</string>
-    <string name="back_menu_send_keys">Send special key(s)</string>
-    <string name="back_menu_send_keys_esc">Send ESC (Menu)</string>
-    <string name="back_menu_send_keys_f11">Send F11 (Exit full screen)</string>
-    <string name="back_menu_send_keys_win">Send WIN (Open Start Menu)</string>
-    <string name="back_menu_send_keys_win_d">Send WIN + D (Switch to Desktop)</string>
-    <string name="back_menu_send_keys_win_g">Send WIN + G (Open Xbox Game Bar)</string>
-    <string name="back_menu_send_keys_shift_tab">Send SHIFT + TAB (Open Steam Overlay)</string>
+    <!-- In Game menu -->
+    <string name="game_menu_disconnect">Disconnect</string>
+    <string name="game_menu_cancel">Cancel</string>
+    <string name="game_menu_send_keys">Send special key(s)</string>
+    <string name="game_menu_send_keys_esc">Send ESC (Menu)</string>
+    <string name="game_menu_send_keys_f11">Send F11 (Toggle full screen)</string>
+    <string name="game_menu_send_keys_win">Send WIN (Toggle Windows start menu)</string>
+    <string name="game_menu_send_keys_win_d">Send WIN + D (Switch to Desktop)</string>
+    <string name="game_menu_send_keys_win_g">Send WIN + G (Open Xbox Game Bar)</string>
+    <string name="game_menu_send_keys_shift_tab">Send SHIFT + TAB (Open Steam Overlay)</string>
 
     <!-- Add computer manually activity -->
     <string name="title_add_pc">Add PC Manually</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,17 @@
     <string name="applist_quit_confirmation">Are you sure you want to quit the running app? All unsaved data will be lost.</string>
     <string name="applist_details_id">App ID:</string>
 
+    <!-- Game back menu -->
+    <string name="back_menu_disconnect">Disconnect</string>
+    <string name="back_menu_cancel">Cancel</string>
+    <string name="back_menu_send_keys">Send special key(s)</string>
+    <string name="back_menu_send_keys_esc">Send ESC (Menu)</string>
+    <string name="back_menu_send_keys_f11">Send F11 (Exit full screen)</string>
+    <string name="back_menu_send_keys_win">Send WIN (Open Start Menu)</string>
+    <string name="back_menu_send_keys_win_d">Send WIN + D (Switch to Desktop)</string>
+    <string name="back_menu_send_keys_win_g">Send WIN + G (Open Xbox Game Bar)</string>
+    <string name="back_menu_send_keys_shift_tab">Send SHIFT + TAB (Open Steam Overlay)</string>
+
     <!-- Add computer manually activity -->
     <string name="title_add_pc">Add PC Manually</string>
     <string name="msg_add_pc">Connecting to the PC…</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -217,11 +217,6 @@
             android:summary="@string/summary_full_range"
             android:defaultValue="false" />
         <CheckBoxPreference
-            android:key="checkbox_enable_perf_overlay"
-            android:title="@string/title_enable_perf_overlay"
-            android:summary="@string/summary_enable_perf_overlay"
-            android:defaultValue="false"/>
-        <CheckBoxPreference
             android:key="checkbox_enable_post_stream_toast"
             android:title="@string/title_enable_post_stream_toast"
             android:summary="@string/summary_enable_post_stream_toast"


### PR DESCRIPTION
This adds an option into the GameMenu allowing us to turn the
performance overlay on/off without needing to exit and go into the
settings.

This MR builds upon #1171 and requires that MR to be merged first.

After #1171 is merged i'll rebase this against master to make the history clean. 

CC: @kmreisi 