### PR TITLE
Analog stick for scrolling in mouse emulation mode

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -1857,21 +1857,30 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         return true;
     }
 
-    private short scaleRawStickAxis(float stickValue) {
-        return (short)Math.pow(stickValue, 3);
-    }
-
-    private void sendEmulatedMouseEvent(short x, short y) {
+    private Vector2d convertRawStickAxisToPixelMovement(short stickX, short stickY) {
         Vector2d vector = new Vector2d();
-        vector.initialize(x, y);
+        vector.initialize(stickX, stickY);
         vector.scalarMultiply(1 / 32766.0f);
         vector.scalarMultiply(4);
         if (vector.getMagnitude() > 0) {
             // Move faster as the stick is pressed further from center
             vector.scalarMultiply(Math.pow(vector.getMagnitude(), 2));
-            if (vector.getMagnitude() >= 1) {
-                conn.sendMouseMove((short)vector.getX(), (short)-vector.getY());
-            }
+        }
+        return vector;
+    }
+
+    private void sendEmulatedMouseMove(short x, short y) {
+        Vector2d vector = convertRawStickAxisToPixelMovement(x, y);
+        if (vector.getMagnitude() >= 1) {
+            conn.sendMouseMove((short)vector.getX(), (short)-vector.getY());
+        }
+    }
+
+    private void sendEmulatedMouseScroll(short x, short y) {
+        Vector2d vector = convertRawStickAxisToPixelMovement(x, y);
+        if (vector.getMagnitude() >= 1) {
+            conn.sendMouseHighResScroll((short)vector.getY());
+            conn.sendMouseHighResHScroll((short)vector.getX());
         }
     }
 
@@ -2906,9 +2915,19 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                     return;
                 }
 
-                // Send mouse movement events from analog sticks
-                sendEmulatedMouseEvent(leftStickX, leftStickY);
-                sendEmulatedMouseEvent(rightStickX, rightStickY);
+                // Send mouse events from analog sticks
+                if (prefConfig.analogStickForScrolling == PreferenceConfiguration.AnalogStickForScrolling.RIGHT) {
+                    sendEmulatedMouseMove(leftStickX, leftStickY);
+                    sendEmulatedMouseScroll(rightStickX, rightStickY);
+                }
+                else if (prefConfig.analogStickForScrolling == PreferenceConfiguration.AnalogStickForScrolling.LEFT) {
+                    sendEmulatedMouseMove(rightStickX, rightStickY);
+                    sendEmulatedMouseScroll(leftStickX, leftStickY);
+                }
+                else {
+                    sendEmulatedMouseMove(leftStickX, leftStickY);
+                    sendEmulatedMouseMove(rightStickX, rightStickY);
+                }
 
                 // Requeue the callback
                 mainThreadHandler.postDelayed(this, mouseEmulationReportPeriod);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -17,6 +17,12 @@ public class PreferenceConfiguration {
         FORCE_H264,
     };
 
+    public enum AnalogStickForScrolling {
+        NONE,
+        RIGHT,
+        LEFT
+    }
+
     private static final String LEGACY_RES_FPS_PREF_STRING = "list_resolution_fps";
     private static final String LEGACY_ENABLE_51_SURROUND_PREF_STRING = "checkbox_51_surround";
 
@@ -44,6 +50,7 @@ public class PreferenceConfiguration {
     private static final String ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay";
     private static final String BIND_ALL_USB_STRING = "checkbox_usb_bind_all";
     private static final String MOUSE_EMULATION_STRING = "checkbox_mouse_emulation";
+    private static final String ANALOG_SCROLLING_PREF_STRING = "analog_scrolling";
     private static final String MOUSE_NAV_BUTTONS_STRING = "checkbox_mouse_nav_buttons";
     static final String UNLOCK_FPS_STRING = "checkbox_unlock_fps";
     private static final String VIBRATE_OSC_PREF_STRING = "checkbox_vibrate_osc";
@@ -80,6 +87,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_ENABLE_PERF_OVERLAY = false;
     private static final boolean DEFAULT_BIND_ALL_USB = false;
     private static final boolean DEFAULT_MOUSE_EMULATION = true;
+    private static final String DEFAULT_ANALOG_STICK_FOR_SCROLLING = "right";
     private static final boolean DEFAULT_MOUSE_NAV_BUTTONS = false;
     private static final boolean DEFAULT_UNLOCK_FPS = false;
     private static final boolean DEFAULT_VIBRATE_OSC = true;
@@ -126,6 +134,7 @@ public class PreferenceConfiguration {
     public boolean enableLatencyToast;
     public boolean bindAllUsb;
     public boolean mouseEmulation;
+    public AnalogStickForScrolling analogStickForScrolling;
     public boolean mouseNavButtons;
     public boolean unlockFps;
     public boolean vibrateOsc;
@@ -384,6 +393,21 @@ public class PreferenceConfiguration {
         }
     }
 
+    private static AnalogStickForScrolling getAnalogStickForScrollingValue(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        String str = prefs.getString(ANALOG_SCROLLING_PREF_STRING, DEFAULT_ANALOG_STICK_FOR_SCROLLING);
+        if (str.equals("right")) {
+            return AnalogStickForScrolling.RIGHT;
+        }
+        else if (str.equals("left")) {
+            return AnalogStickForScrolling.LEFT;
+        }
+        else {
+            return AnalogStickForScrolling.NONE;
+        }
+    }
+
     public static void resetStreamingSettings(Context context) {
         // We consider resolution, FPS, bitrate, HDR, and video format as "streaming settings" here
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
@@ -531,6 +555,8 @@ public class PreferenceConfiguration {
 
         config.videoFormat = getVideoFormatValue(context);
         config.framePacing = getFramePacingValue(context);
+
+        config.analogStickForScrolling = getAnalogStickForScrollingValue(context);
 
         config.deadzonePercentage = prefs.getInt(DEADZONE_PREF_STRING, DEFAULT_DEADZONE);
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -270,4 +270,9 @@
     <string name="pair_pairing_help">Wenn dein Host PC Sunshine verwendet, navigiere zur Sunshine Web UI und gebe dort die PIN ein.</string>
     <string name="title_checkbox_gamepad_touchpad_as_mouse">Die Maus immer mit dem Touchpad steuern</string>
     <string name="perf_overlay_hostprocessinglatency">Host Verarbeitungslatenz min/max/avg: %1$.1f/%2$.1f/%3$.1f ms</string>
+    <string name="title_analog_scrolling">Verwenden Sie zum Scrollen einen Analogstick</string>
+    <string name="summary_analog_scrolling">Wählen Sie einen Analogstick aus, der zum scrollen im Mausemulationsmodus verwendet werden soll</string>
+    <string name="analogscroll_none">Keine (beide Sticks bewegen die Maus)</string>
+    <string name="analogscroll_right">Rechter Analogstick</string>
+    <string name="analogscroll_left">Linker Analogstick</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -278,4 +278,9 @@
     <string name="summary_checkbox_gamepad_motion_fallback">Utiliza los sensores de movimiento integrados de tu dispositivo si el gamepad conectado o tu versión de Android no admiten los sensores del gamepad.
 \nNota: Activar esta opción puede hacer que tu gamepad aparezca como un mando de PlayStation en el host.</string>
     <string name="title_checkbox_gamepad_motion_fallback">Emular el sensor de movimiento del gamepad</string>
+    <string name="analogscroll_none">Ninguno (ambos joysticks mueven el mouse)</string>
+    <string name="analogscroll_right">Joystick analógico derecho</string>
+    <string name="analogscroll_left">Joystick analógico izquierdo</string>
+    <string name="title_analog_scrolling">Usa un joystick analógico para hacer scroll</string>
+    <string name="summary_analog_scrolling">Selecciona un joystick analógico para scroll cuando la emulación del mouse está habilitada</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -278,4 +278,9 @@
     <string name="summary_checkbox_gamepad_motion_fallback">Utilise les capteurs de mouvement de votre appareil si la manette connéctée n\'en a pas, ou qu\'ils ne sont pas pris en charge par votre version d\'Android.
 \nRemarque : l\'activation de cette option peut faire apparaître votre manette de jeu comme une manette PlayStation du côté hôte.</string>
     <string name="title_checkbox_gamepad_motion_fallback">Émuler les capteurs de mouvement de la manette</string>
+    <string name="title_analog_scrolling">Utilisez un stick analogique pour faire défiler</string>
+    <string name="summary_analog_scrolling">Sélectionnez un stick analogique pour faire défiler en mode émulation de la souris</string>
+    <string name="analogscroll_none">Aucun (les deux sticks déplacent la souris)</string>
+    <string name="analogscroll_right">Stick analogique droit</string>
+    <string name="analogscroll_left">Stick analogique gauche</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -249,4 +249,9 @@
 \n
 \nTente desativar o modo HDR, alterar a resolução de streaming ou alterar a resolução do PC host.</string>
     <string name="summary_full_range">Isso causará perda de detalhes em áreas claras e escuras se o seu dispositivo não exibir corretamente todo o conteúdo de vídeo em cores.</string>
+    <string name="analogscroll_none">Nenhum (ambos os sticks movem o rato)</string>
+    <string name="analogscroll_right">Stick analógico direito</string>
+    <string name="analogscroll_left">Stick analógico esquerdo</string>
+    <string name="title_analog_scrolling">Usar um stick analógico para fazer scroll</string>
+    <string name="summary_analog_scrolling">Selecciona um stick analógico para fazer scroll quando a emulação de rato está ativada</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -249,4 +249,9 @@
     <string name="resolution_480p">480p</string>
     <string name="resolution_720p">720p</string>
     <string name="summary_frame_pacing">Especifique o equilíbrio entre latência e suavidade do vídeo</string>
+    <string name="analogscroll_none">Nenhum (ambos os sticks movem o rato)</string>
+    <string name="analogscroll_right">Stick analógico direito</string>
+    <string name="analogscroll_left">Stick analógico esquerdo</string>
+    <string name="title_analog_scrolling">Usar um stick analógico para fazer scroll</string>
+    <string name="summary_analog_scrolling">Selecciona um stick analógico para fazer scroll quando a emulação de rato está ativada</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -120,4 +120,15 @@
         <item>cap-fps</item>
         <item>smoothness</item>
     </string-array>
+
+    <string-array name="analog_scrolling_names">
+        <item>@string/analogscroll_none</item>
+        <item>@string/analogscroll_right</item>
+        <item>@string/analogscroll_left</item>
+    </string-array>
+    <string-array name="analog_scrolling_values" translatable="false">
+        <item>none</item>
+        <item>right</item>
+        <item>left</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,4 +289,10 @@
     <string name="pacing_balanced">Balanced</string>
     <string name="pacing_balanced_alt">Balanced with FPS limit</string>
     <string name="pacing_smoothness">Prefer smoothest video (may significantly increase latency)</string>
+
+    <string name="title_analog_scrolling">Use an analog stick to scroll</string>
+    <string name="summary_analog_scrolling">Select an analog stick to scroll when in mouse emulation mode</string>
+    <string name="analogscroll_none">None (both sticks move the mouse)</string>
+    <string name="analogscroll_right">Right analog stick</string>
+    <string name="analogscroll_left">Left analog stick</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,6 +85,14 @@
             android:title="@string/title_checkbox_mouse_emulation"
             android:summary="@string/summary_checkbox_mouse_emulation"
             android:defaultValue="true" />
+        <ListPreference
+            android:key="analog_scrolling"
+            android:dependency="checkbox_mouse_emulation"
+            android:title="@string/title_analog_scrolling"
+            android:summary="@string/summary_analog_scrolling"
+            android:entries="@array/analog_scrolling_names"
+            android:entryValues="@array/analog_scrolling_values"
+            android:defaultValue="right" />
         <CheckBoxPreference
             android:key="checkbox_vibrate_fallback"
             android:title="@string/title_checkbox_vibrate_fallback"


### PR DESCRIPTION
I often use my gamepad to browse through websites (in between gaming sessions) using mouse-emulation mode. I really wished I could scroll with an analog stick, and then I remembered moonlight is open source and I can code 😄

### Configurable

- I have made this configurable, you can choose between right stick for scrolling, left stick, or none (both sticks move the mouse, which is the current behaviour)
- I have made the default be right stick for scrolling - feels more natural. This does change the current behaviour and might surprise users (but hopefully most will be surprised for the best...). I would be ok with setting the default to "none" to keep current behaviour.

### Translations

I wasn't sure of how many translation strings to add, so I added 5 popular languages that I more or less know.