### PR TITLE
Add Vendor 8BitDo to Xbox360Controller

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/Xbox360Controller.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/Xbox360Controller.java
@@ -39,6 +39,7 @@ public class Xbox360Controller extends AbstractXboxController {
             0x20d6, // PowerA
             0x24c6, // PowerA
             0x2f24, // GameSir
+            0x2dc8, // 8BitDo
     };
 
     public static boolean canClaimDevice(UsbDevice device) {


### PR DESCRIPTION
8BitDo Ultimate Bluetooth Controller was not being recognized in XInput mode when using the dongle. It also doesn't work natively on Android interface so it was unusable in Moonlight. Adding 8BitDo's Vendor ID to SUPPORTED_VENDORS seems to fix it for Moonlight.