### PR TITLE
Fix rumble not working due to deprecated API call

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -133,7 +133,16 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         this.conn = conn;
         this.gestures = gestures;
         this.prefConfig = prefConfig;
-        this.deviceVibrator = (Vibrator) activityContext.getSystemService(Context.VIBRATOR_SERVICE);
+		
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            this.deviceVibratorManager = (VibratorManager) activityContext.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            this.deviceVibrator = (Vibrator) this.deviceVibratorManager.getDefaultVibrator();
+        }
+        else {
+            this.deviceVibratorManager = null;
+            this.deviceVibrator = (Vibrator) activityContext.getSystemService(Context.VIBRATOR_SERVICE);
+        }
+		
         this.deviceSensorManager = (SensorManager) activityContext.getSystemService(Context.SENSOR_SERVICE);
         this.inputManager = (InputManager) activityContext.getSystemService(Context.INPUT_SERVICE);
         this.mainThreadHandler = new Handler(Looper.getMainLooper());
@@ -143,13 +152,6 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         this.backgroundHandlerThread = new HandlerThread("ControllerHandler");
         this.backgroundHandlerThread.start();
         this.backgroundThreadHandler = new Handler(backgroundHandlerThread.getLooper());
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            this.deviceVibratorManager = (VibratorManager) activityContext.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
-        }
-        else {
-            this.deviceVibratorManager = null;
-        }
 
         this.sceManager = new SceManager(activityContext);
         this.sceManager.start();


### PR DESCRIPTION
The constant `VIBRATOR_SERVICE` is marked as deprecated in API level 31. According to [this post on Stack Overflow](https://stackoverflow.com/a/69373533), the correct way to get the system default `Vibrator` instance is to retrieve it from the `VibratorManager` service, which the original code already has but isn't used to retrieve the `Vibrator` instance.

My Redmi K40 was affected by this, and there was no on-device rumble even if no external controller is connected. By applying the patched code, the rumble works as expected. As the original usage is deprecated, I'd expect this patch would help Moonlight work better on more newer devices and systems.