### PR TITLE
Unlock that bitrate for gigabit tests!

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,7 +22,7 @@
             android:key="seekbar_bitrate_kbps"
             android:dialogMessage="@string/summary_seekbar_bitrate"
             seekbar:min="500"
-            android:max="150000"
+            android:max="900000"
             seekbar:step="500"
             seekbar:keyStep="1000"
             seekbar:divisor="1000"


### PR DESCRIPTION
The base android app cap of 150Mbps bitrate is way too low, we need to test with up to 900Mbps for gigabit. 