### PR TITLE
Add Vendor 8BitDo to XboxOneController

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/XboxOneController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/XboxOneController.java
@@ -25,6 +25,7 @@ public class XboxOneController extends AbstractXboxController {
             0x20d6, // PowerA
             0x24c6, // PowerA
             0x2e24, // Hyperkin
+            0x2dc8, // 8BitDo
     };
 
     private static final byte[] FW2015_INIT = {0x05, 0x20, 0x00, 0x01, 0x00};


### PR DESCRIPTION
Some new 8BitDo controller or adapter are now detected as XboxOne controller instead of Xbox360 controller in XInput mode like the 8BitDo Ultimate-3-mode (https://www.8bitdo.com/ultimate-3-mode-controller-xbox/).

Like commit #1333 (https://github.com/moonlight-stream/moonlight-android/pull/1333/commits), adding 8BitDo's Vendor ID to SUPPORTED_VENDORS improve compatibility and enable rumble for supported controller.