### PR TITLE
Added github workflow and added nightly build plus pre-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,115 @@
+---
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 9477386
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'adopt'
+
+      - name: Set up environment
+        run: |
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
+          echo "COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Decode debug keystore
+        env:
+          DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
+        run: |
+          if [ -z "$DEBUG_KEYSTORE" ]
+          then
+            echo "No debug keystore value"
+          else
+            echo $DEBUG_KEYSTORE > debug.keystore.base64
+            base64 --decode debug.keystore.base64 > debug.keystore
+            sudo cp -f debug.keystore /root/.android/.
+          fi
+
+      - name: Build artifact
+        run: ./gradlew assemble
+
+      - name: Copy artifact
+        run: |
+          mkdir moonlight-android
+          cp app/build/outputs/apk/root/debug/app-root-debug.apk "moonlight-android/app-root-debug-${COMMIT_PREFIX}.apk"
+          cp app/build/outputs/apk/nonRoot/debug/app-nonRoot-debug.apk "moonlight-android/app-nonRoot-debug-${COMMIT_PREFIX}.apk"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: moonlight-android
+          path: ${{ github.workspace }}/moonlight-android
+          if-no-files-found: error
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Re-zip artifacts
+        run: |
+          cd dist
+          COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)
+          for artifact in *.apk
+          do
+            file_name="${artifact%.apk}"
+            echo "-> Creating ${file_name//-${COMMIT_PREFIX}/}.zip"
+            zip "${file_name//-${COMMIT_PREFIX}/}.zip" "${file_name}.apk"
+          done
+
+      - name: Update Git Tag
+        run: |
+          git tag -f Pre-release
+          git push -f origin Pre-release
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: true
+          allowUpdates: true
+          removeArtifacts: true
+          replacesArtifacts: false
+          tag: Pre-release
+          artifacts: "dist/*.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,115 @@
+---
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: android-actions/setup-android@v4
+        with:
+          cmdline-tools-version: 9477386
+
+      - uses: actions/setup-java@v6
+        with:
+          java-version: '25'
+          distribution: temurin
+
+      - name: Set up environment
+        run: |
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
+          echo "COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Decode debug keystore
+        env:
+          DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
+        run: |
+          if [ -z "$DEBUG_KEYSTORE" ]
+          then
+            echo "No debug keystore value"
+          else
+            echo $DEBUG_KEYSTORE > debug.keystore.base64
+            base64 --decode debug.keystore.base64 > debug.keystore
+            sudo cp -f debug.keystore /root/.android/.
+          fi
+
+      - name: Build artifact
+        run: ./gradlew assemble
+
+      - name: Copy artifact
+        run: |
+          mkdir moonlight-android
+          cp app/build/outputs/apk/root/debug/app-root-debug.apk "moonlight-android/app-root-debug-${COMMIT_PREFIX}.apk"
+          cp app/build/outputs/apk/nonRoot/debug/app-nonRoot-debug.apk "moonlight-android/app-nonRoot-debug-${COMMIT_PREFIX}.apk"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: moonlight-android
+          path: ${{ github.workspace }}/moonlight-android
+          if-no-files-found: error
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Re-zip artifacts
+        run: |
+          cd dist
+          COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)
+          for artifact in *.apk
+          do
+            file_name="${artifact%.apk}"
+            echo "-> Creating ${file_name//-${COMMIT_PREFIX}/}.zip"
+            zip "${file_name//-${COMMIT_PREFIX}/}.zip" "${file_name}.apk"
+          done
+
+      - name: Update Git Tag
+        run: |
+          git tag -f Pre-release
+          git push -f origin Pre-release
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: true
+          allowUpdates: true
+          removeArtifacts: true
+          replacesArtifacts: false
+          tag: Pre-release
+          artifacts: "dist/*.zip"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ You can follow development on our [Discord server](https://moonlight-stream.org/
 * [F-Droid](https://f-droid.org/packages/com.limelight)
 * [APK](https://github.com/moonlight-stream/moonlight-android/releases)
 
+## Nightly builds
+| Name                    | Status                            | File                                                |
+|-------------------------|-----------------------------------|-----------------------------------------------------|
+| app nonRoot debug       | [![Build Status][Build]][Actions] | [![moonlight-android][Download]][app nonRoot debug] |
+| app Root debug          | [![Build Status][Build]][Actions] | [![moonlight-android][Download]][app root debug]    |
+
+[Actions]: https://github.com/moonlight-stream/moonlight-android/actions/workflows/build.yml
+[Build]: https://github.com/moonlight-stream/moonlight-android/actions/workflows/build.yml/badge.svg
+[Download]: https://img.shields.io/badge/Download-blue
+[app nonRoot debug]: https://github.com/moonlight-stream/moonlight-android/releases/download/Pre-release/app-nonRoot-debug.zip
+[app root debug]: https://github.com/moonlight-stream/moonlight-android/releases/download/Pre-release/app-root-debug.zip
+
 ## Building
 * Install Android Studio and the Android NDK
 * Run ‘git submodule update --init --recursive’ from within moonlight-android/
@@ -26,9 +38,9 @@ You can follow development on our [Discord server](https://moonlight-stream.org/
 
 ## Authors
 
-* [Cameron Gutman](https://github.com/cgutman)  
-* [Diego Waxemberg](https://github.com/dwaxemberg)  
-* [Aaron Neyer](https://github.com/Aaronneyer)  
+* [Cameron Gutman](https://github.com/cgutman)
+* [Diego Waxemberg](https://github.com/dwaxemberg)
+* [Aaron Neyer](https://github.com/Aaronneyer)
 * [Andrew Hennessy](https://github.com/yetanothername)
 
 Moonlight is the work of students at [Case Western](http://case.edu) and was


### PR DESCRIPTION
Hi @cgutman,

I have added the following, which I think will help to collect feedback before releasing a new version:
- A Github CI workflow to build the debug apk's for root and nonRoot.

**Important notice**: It generates a "debug keystore" everytime the pipeline runs, to always use the same "debug keystore" you can use the following command from a machine with Android Studio: **base64 --wrap=0 .android/debug.keystore > encodedData.txt**

After that you can add it under "Settings" of the repository, click on "Secrets and Variables" under "Security", click on "Actions" and click on "New repository secret". The name should be "DEBUG_KEYSTORE" and the value retrieved with the command.
![image](https://github.com/user-attachments/assets/4447e488-1318-4738-85bc-8fc90e1f053b). This will ensure users are able to upgrade to a newer version of a debug client, because the debug signing key will be the same.
- Added a pre-release, which will release automatically after a PR has been merged to main. The apk debug files will contain the commit sha in the filenames and only the files of the last commit will be available.
![image](https://github.com/user-attachments/assets/b38a7fce-a200-4ad0-80be-981250c12c5c)
- Added a nightly builds section for root and nonRoot in the README, which looks like the following
![image](https://github.com/user-attachments/assets/66758eec-3e37-4fdb-942a-4b1f0d549410)
