### PR TITLE
External Display Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.1'
+        classpath 'com.android.tools.build:gradle:8.8.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
So I made this [feature request](https://github.com/moonlight-stream/moonlight-android/issues/1475) yesterday and I figured "wth, I'll just do it myself."

TL:DR:

After figuring out that Samsung DeX can in fact use higher resolutions (thanks to the Good Lock app and its plugin MultiStar) I realized that within Samsung DeX the Moonlight settings show neither the external monitor's resolution and framerate capabilities nor the ones of the phone. That has now changed.


What I did:
- Changed one line of code to not just find the default phone display but to find all available displays and made the "native settings section" (lines 354 - 613) loop through all available displays.
- Added the import of DisplayManager (line 29) 
- I let Android Studio change some dependencies to newer version.
- Tested the changes on a Samsung Note 20 Ultra 5G within and outside Samsung DeX

What I did not do:
- Test on other phones and/or Android versions.


I really hope this will get pulled soon and we can see the new version of Moonlight in the app stores.