### PR TITLE
Update UI helper to not fail on Meta Quest devices

### DIFF
--- a/app/src/main/java/com/limelight/utils/UiHelper.java
+++ b/app/src/main/java/com/limelight/utils/UiHelper.java
@@ -31,13 +31,19 @@ public class UiHelper {
 
     private static void setGameModeStatus(Context context, boolean streaming, boolean interruptible) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            GameManager gameManager = context.getSystemService(GameManager.class);
+            try {
+                GameManager gameManager = context.getSystemService(GameManager.class);
+                if (gameManager == null) {
+                    return; // Not supported on this device (e.g., Meta Quest)
+                }
 
-            if (streaming) {
-                gameManager.setGameState(new GameState(false, interruptible ? GameState.MODE_GAMEPLAY_INTERRUPTIBLE : GameState.MODE_GAMEPLAY_UNINTERRUPTIBLE));
-            }
-            else {
-                gameManager.setGameState(new GameState(false, GameState.MODE_NONE));
+                if (streaming) {
+                    gameManager.setGameState(new GameState(false, interruptible ? GameState.MODE_GAMEPLAY_INTERRUPTIBLE : GameState.MODE_GAMEPLAY_UNINTERRUPTIBLE));
+                } else {
+                    gameManager.setGameState(new GameState(false, GameState.MODE_NONE));
+                }
+            } catch (Throwable t) {
+                // Swallow any failure. Some OEM builds ship partial/incompatible GameManager impls.
             }
         }
     }


### PR DESCRIPTION
Meta Quest devices are using Android 14, but it's not full Android, it doesn't have some features as for example Game Manager. When trying to run moonlight on meta quest, it crashes. This PR just adds some checks and fixes an issues for Meta Quest without affecting other devices. 
![916cf923fc542c78b9dbea0bd479f0f7](https://github.com/user-attachments/assets/a89c872c-392e-43a8-8b9f-4ac68ec630e4)

fixes https://github.com/moonlight-stream/moonlight-android/issues/1492, fixes https://github.com/moonlight-stream/moonlight-android/issues/1503