### PR TITLE
TLS 1.2 for older android versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,4 +142,5 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.jmdns:jmdns:3.5.9'
     implementation 'com.github.cgutman:ShieldControllerExtensions:1.0.1'
+    implementation "org.conscrypt:conscrypt-android:2.5.2"
 }

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.java
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.java
@@ -18,7 +18,9 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -42,6 +44,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.conscrypt.Conscrypt;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -172,7 +175,25 @@ public class NvHTTP {
             }
         };
 
+        Provider conscrypt = Conscrypt.newProvider();
+        Security.insertProviderAt(conscrypt, 1);
+
+        TrustManager[] trustManagers = null;
+        SSLContext sslContext = null;
+        SSLSocketFactory sslSocketFactory = null;
+        try {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init((KeyStore) null);
+            trustManagers = tmf.getTrustManagers();
+            sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagers, new SecureRandom());
+            sslSocketFactory = sslContext.getSocketFactory();
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+
         httpClientLongConnectTimeout = new OkHttpClient.Builder()
+                .sslSocketFactory(sslSocketFactory, (X509TrustManager) trustManagers[0])
                 .connectionPool(new ConnectionPool(0, 1, TimeUnit.MILLISECONDS))
                 .hostnameVerifier(hv)
                 .readTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
This PR addresses handshake failures on older Android devices (5.0–5.1.x) when connecting to Sunshine/Moonlight. The issue is caused by Android 5’s outdated TLS stack, which does not fully support TLS 1.2. Modern Sunshine servers require TLS 1.2, and legacy protocols like TLS 1.0 or 1.1 are no longer supported or secure, so server-side changes are not a safe option.

The fix adds Conscrypt as a client-side TLS provider and configures Moonlight to use it for secure connections. Conscrypt provides full TLS 1.2 support on Android 5 devices, ensuring the handshake completes successfully without lowering server security. This patch is entirely client-side and does not affect newer Android versions or server configurations.

Tested on a Samsung P600 running Android 5.1.1, the patch allows pairing and streaming with Sunshine. It works alongside modern devices and preserves compatibility with existing TLS configurations. This ensures older devices remain supported without compromising security for other users.

Fixes these bugs:
https://github.com/moonlight-stream/moonlight-android/issues/1228
https://github.com/moonlight-stream/moonlight-android/issues/1300