### PR TITLE
Add GameSir vendor IDs for G7 Pro and other GIP controllers

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/Xbox360Controller.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/Xbox360Controller.java
@@ -39,6 +39,7 @@ public class Xbox360Controller extends AbstractXboxController {
             0x20d6, // PowerA
             0x24c6, // PowerA
             0x2f24, // GameSir
+            0x3537, // GameSir (G7 Pro / Cyclone 2 / Kaleid Flux)
             0x2dc8, // 8BitDo
     };
 

--- a/app/src/main/java/com/limelight/binding/input/driver/XboxOneController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/XboxOneController.java
@@ -25,6 +25,8 @@ public class XboxOneController extends AbstractXboxController {
             0x20d6, // PowerA
             0x24c6, // PowerA
             0x2e24, // Hyperkin
+            0x2f24, // GameSir
+            0x3537, // GameSir (G7 Pro / Cyclone 2 / Kaleid Flux)
     };
 
     private static final byte[] FW2015_INIT = {0x05, 0x20, 0x00, 0x01, 0x00};


### PR DESCRIPTION
Add GameSir VID 0x3537 (used by G7 Pro, Cyclone 2, Kaleid Flux) and 0x2f24 (older GameSir controllers) to the Xbox One and Xbox 360 SUPPORTED_VENDORS lists.

Without these VIDs, GameSir G7 Pro controllers connected via USB were not recognized by the Xbox One/360 driver, preventing rumble and proper input handling. The G7 Pro is an Xbox-licensed controller using the standard GIP protocol (interface class=0xFF, subclass=0x47, protocol=0xD0).