### PR TITLE
feat: add 'Keep screen awake' setting to prevent screen lock during streaming

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -219,6 +219,11 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         prefConfig = PreferenceConfiguration.readPreferences(this);
         tombstonePrefs = Game.this.getSharedPreferences("DecoderTombstone", 0);
 
+        // Keep the display on during streaming if preference is enabled
+        if (prefConfig.keepScreenOn) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
+
         // Enter landscape unless we're on a square screen
         setPreferredOrientationForCurrentDisplay();
 
@@ -2408,9 +2413,6 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                         setInputGrabState(true);
                     }
                 }, 500);
-
-                // Keep the display on
-                getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
                 // Update GameManager state to indicate we're in game
                 UiHelper.notifyStreamConnected(Game.this);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -68,6 +68,7 @@ public class PreferenceConfiguration {
     private static final String GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING = "checkbox_gamepad_touchpad_as_mouse";
     private static final String GAMEPAD_MOTION_SENSORS_PREF_STRING = "checkbox_gamepad_motion_sensors";
     private static final String GAMEPAD_MOTION_FALLBACK_PREF_STRING = "checkbox_gamepad_motion_fallback";
+    private static final String KEEP_SCREEN_ON_PREF_STRING = "checkbox_keep_screen_on";
 
     static final String DEFAULT_RESOLUTION = "1280x720";
     static final String DEFAULT_FPS = "60";
@@ -108,6 +109,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE = false;
     private static final boolean DEFAULT_GAMEPAD_MOTION_SENSORS = true;
     private static final boolean DEFAULT_GAMEPAD_MOTION_FALLBACK = false;
+    private static final boolean DEFAULT_KEEP_SCREEN_ON = true;
 
     public static final int FRAME_PACING_MIN_LATENCY = 0;
     public static final int FRAME_PACING_BALANCED = 1;
@@ -155,6 +157,7 @@ public class PreferenceConfiguration {
     public boolean gamepadMotionSensors;
     public boolean gamepadTouchpadAsMouse;
     public boolean gamepadMotionSensorsFallbackToDevice;
+    public boolean keepScreenOn;
 
     public static boolean isNativeResolution(int width, int height) {
         // It's not a native resolution if it matches an existing resolution option
@@ -601,6 +604,7 @@ public class PreferenceConfiguration {
         config.gamepadTouchpadAsMouse = prefs.getBoolean(GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING, DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE);
         config.gamepadMotionSensors = prefs.getBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, DEFAULT_GAMEPAD_MOTION_SENSORS);
         config.gamepadMotionSensorsFallbackToDevice = prefs.getBoolean(GAMEPAD_MOTION_FALLBACK_PREF_STRING, DEFAULT_GAMEPAD_MOTION_FALLBACK);
+        config.keepScreenOn = prefs.getBoolean(KEEP_SCREEN_ON_PREF_STRING, DEFAULT_KEEP_SCREEN_ON);
 
         return config;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,8 @@
     <string name="summary_seekbar_bitrate">Increase for better image quality. Decrease to improve performance on slower connections.</string>
     <string name="suffix_seekbar_bitrate_mbps">Mbps</string>
     <string name="title_checkbox_stretch_video">Stretch video to full-screen</string>
+    <string name="title_checkbox_keep_screen_on">Keep screen awake</string>
+    <string name="summary_checkbox_keep_screen_on">Prevent screen from locking during streaming</string>
     <string name="resolution_prefix_native">Native</string>
     <string name="resolution_prefix_native_fullscreen">Native Full-Screen</string>
     <string name="resolution_prefix_native_landscape">(Landscape)</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -40,6 +40,11 @@
             android:key="checkbox_stretch_video"
             android:title="@string/title_checkbox_stretch_video"
             android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_keep_screen_on"
+            android:title="@string/title_checkbox_keep_screen_on"
+            android:summary="@string/summary_checkbox_keep_screen_on"
+            android:defaultValue="true" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_audio_settings">
         <ListPreference


### PR DESCRIPTION
Resolves #1549

## Summary

Adds a new preference option **"Keep screen awake"** in Basic Settings that prevents the Android screen from locking during streaming.

## Problem

Users reported that their Android device screen would lock during streaming sessions, especially when using Moonlight as a remote desktop for extended periods without touch input (e.g., watching movies, using Bluetooth keyboard/mouse).

## Solution

- Added a new checkbox preference "Keep screen awake" in Settings > Basic Settings
- Default: **enabled** (preserves current behavior)
- When enabled: sets `FLAG_KEEP_SCREEN_ON` to prevent screen lock
- When disabled: screen can lock based on system timeout settings

## Changes

- `PreferenceConfiguration.java`: Added preference constant, field, and reading logic
- `preferences.xml`: Added CheckBoxPreference in Basic Settings category
- `strings.xml`: Added title and summary strings
- `Game.java`: Set `FLAG_KEEP_SCREEN_ON` in `onCreate()` based on preference

## Testing

- [ ] Setting appears in Settings > Basic Settings
- [ ] Default is enabled (screen stays awake during streaming)
- [ ] Disabling the setting allows screen to lock during streaming
- [ ] No effect when streaming is not active