### PR TITLE
Add Video Super Resolution

### DIFF
--- a/app/src/main/assets/sgsr1_shader_mobile_edge_direction.frag
+++ b/app/src/main/assets/sgsr1_shader_mobile_edge_direction.frag
@@ -1,0 +1,137 @@
+#version 310 es
+
+//============================================================================================================
+//
+//                  Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+//                              SPDX-License-Identifier: BSD-3-Clause
+//
+//============================================================================================================
+
+// Fallback if the defines are not injected dynamically
+#ifndef SRC_W
+#define SRC_W 1280.0
+#define SRC_H 720.0
+#define INV_SRC_W (1.0 / 1280.0)
+#define INV_SRC_H (1.0 / 720.0)
+#endif
+
+precision mediump float;
+precision mediump int;
+
+////////////////////////
+// USER CONFIGURATION //
+////////////////////////
+
+#define EdgeThreshold (8.0 / 255.0)
+#define EdgeSharpness 2.0
+
+////////////////////////
+////////////////////////
+////////////////////////
+
+// ViewportInfo is a compile-time constant expression for optimal performance
+const mediump vec4 ViewportInfo = vec4(INV_SRC_W, INV_SRC_H, SRC_W, SRC_H);
+
+uniform mediump sampler2D ps0;
+
+// Variables passed down from the Vertex Shader to avoid per-pixel calculations
+in mediump vec2 v_texCoord;
+in mediump vec2 v_imgCoord;
+
+out mediump vec4 out_Target0;
+
+mediump float fastLanczos2(mediump float x)
+{
+	mediump float wA = x - 4.0;
+	mediump float wB = x * wA - wA;
+	return wB * (wA * wA);
+}
+
+mediump vec2 weightY(mediump vec2 d, mediump float c, mediump vec3 data)
+{
+	mediump float std = data.x;
+	mediump vec2 dir = data.yz;
+
+	mediump float edgeDis = dot(d, dir.yx);
+	mediump float x = dot(d, d) + (edgeDis * edgeDis) * (clamp((c * c) * std, 0.0, 1.0) * 0.7 - 1.0);
+
+	return vec2(1.0, c) * fastLanczos2(x);
+}
+
+mediump vec2 edgeDirection(mediump vec4 left, mediump vec4 right)
+{
+	mediump float RxLz = right.x - left.z;
+	mediump float RwLy = right.w - left.y;
+	mediump vec2 delta = vec2(RxLz + RwLy, RxLz - RwLy);
+	mediump float lengthInv = inversesqrt(dot(delta, delta) + 3.075740e-05);
+
+	return delta * lengthInv;
+}
+
+void main()
+{
+	mediump vec4 color = textureLod(ps0, v_texCoord, 0.0);
+
+	mediump vec2 coord = floor(v_imgCoord) * ViewportInfo.xy;
+	mediump vec2 pl = fract(v_imgCoord);
+
+	mediump vec4 left = textureGather(ps0, coord, 1);
+
+	mediump float edgeVote = abs(left.z - left.y) + abs(color.y - left.y) + abs(color.y - left.z);
+
+	if(edgeVote > EdgeThreshold)
+	{
+		coord.x += ViewportInfo.x;
+
+		mediump vec4 right = textureGather(ps0, coord + vec2(ViewportInfo.x, 0.0), 1);
+		mediump vec4 upDown;
+		upDown.xy = textureGather(ps0, coord + vec2(0.0, -ViewportInfo.y), 1).wz;
+		upDown.zw = textureGather(ps0, coord + vec2(0.0, ViewportInfo.y), 1).yx;
+
+		mediump float mean = (left.y + left.z + right.x + right.w) * 0.25;
+
+		left -= mean;
+		right -= mean;
+		upDown -= mean;
+		color.w = color.y - mean;
+
+		mediump float sum = dot(abs(left), vec4(1.0))
+		                  + dot(abs(right), vec4(1.0))
+		                  + dot(abs(upDown), vec4(1.0));
+
+		mediump float sumMean = 10.14185 / sum;
+		mediump float std = sumMean * sumMean;
+
+		mediump vec3 data = vec3(std, edgeDirection(left, right));
+
+		mediump vec2 aWY = weightY(pl + vec2(0.0, 1.0), upDown.x, data);
+		aWY += weightY(pl + vec2(-1.0, 1.0), upDown.y, data);
+		aWY += weightY(pl + vec2(-1.0, -2.0), upDown.z, data);
+		aWY += weightY(pl + vec2(0.0, -2.0), upDown.w, data);
+		aWY += weightY(pl + vec2(1.0, -1.0), left.x, data);
+		aWY += weightY(pl + vec2(0.0, -1.0), left.y, data);
+		aWY += weightY(pl, left.z, data);
+		aWY += weightY(pl + vec2(1.0, 0.0), left.w, data);
+		aWY += weightY(pl + vec2(-1.0, -1.0), right.x, data);
+		aWY += weightY(pl + vec2(-2.0, -1.0), right.y, data);
+		aWY += weightY(pl + vec2(-2.0, 0.0), right.z, data);
+		aWY += weightY(pl + vec2(-1.0, 0.0), right.w, data);
+
+		mediump float finalY = aWY.y / aWY.x;
+
+		mediump vec2 leftYZ_rightXW = vec2(max(left.y, left.z), max(right.x, right.w));
+		mediump float maxY = max(leftYZ_rightXW.x, leftYZ_rightXW.y);
+
+		mediump vec2 min_leftYZ_rightXW = vec2(min(left.y, left.z), min(right.x, right.w));
+		mediump float minY = min(min_leftYZ_rightXW.x, min_leftYZ_rightXW.y);
+
+		mediump float deltaY = clamp(EdgeSharpness * finalY, minY, maxY) - color.w;
+
+		deltaY = clamp(deltaY, -23.0 / 255.0, 23.0 / 255.0);
+
+		color.rgb = clamp(color.rgb + deltaY, 0.0, 1.0);
+	}
+
+	color.w = 1.0;
+	out_Target0 = color;
+}

--- a/app/src/main/java/com/limelight/binding/video/GlesPassthroughBridge.java
+++ b/app/src/main/java/com/limelight/binding/video/GlesPassthroughBridge.java
@@ -1,0 +1,517 @@
+package com.limelight.binding.video;
+
+import android.content.Context;
+import android.graphics.SurfaceTexture;
+import android.opengl.EGL14;
+import android.opengl.EGLConfig;
+import android.opengl.EGLContext;
+import android.opengl.EGLDisplay;
+import android.opengl.EGLExt;
+import android.opengl.EGLSurface;
+import android.opengl.GLES11Ext;
+import android.opengl.GLES31;
+import android.view.Surface;
+import com.limelight.LimeLog;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * This class acts as a bridge between the MediaCodec decoder and the final display surface.
+ * It implements a Two-Pass OpenGL ES 3.1 Pipeline to support standard sampler2D shaders (like SGSR1).
+ * 
+ * Pass 1: Renders the hardware-decoded OES texture (samplerExternalOES) into a standard 2D texture via an FBO.
+ * Pass 2: Applies the custom post-processing shader (e.g., SGSR1) on the 2D texture and renders it to the display.
+ */
+public class GlesPassthroughBridge implements SurfaceTexture.OnFrameAvailableListener {
+    private static final String TAG = "GlesBridge";
+
+    // --- PASS 1: OES to 2D Texture ---
+    // Vertex shader for the first pass (hardware decode to FBO)
+    private static final String BLIT_VERTEX_SHADER =
+            "#version 310 es\n" +
+            "uniform mat4 uSTMatrix;\n" +
+            "in vec4 aPosition;\n" +
+            "in vec4 aTexCoord;\n" +
+            "out vec2 vTexCoord;\n" +
+            "void main() {\n" +
+            "  gl_Position = aPosition;\n" +
+            "  vTexCoord = (uSTMatrix * aTexCoord).xy;\n" + // Apply the SurfaceTexture transform matrix
+            "}\n";
+
+    // Fragment shader for the first pass (reads from OES texture)
+    private static final String BLIT_FRAGMENT_SHADER =
+            "#version 310 es\n" +
+            "#extension GL_OES_EGL_image_external_essl3 : require\n" +
+            "precision mediump float;\n" +
+            "in vec2 vTexCoord;\n" +
+            "uniform samplerExternalOES sTexture;\n" +
+            "out vec4 fragColor;\n" +
+            "void main() {\n" +
+            "  fragColor = texture(sTexture, vTexCoord);\n" +
+            "}\n";
+
+    // Fallback shader used if the external custom shader (e.g., SGSR) fails to load
+    private static final String FALLBACK_POST_FRAGMENT_SHADER =
+            "#version 310 es\n" +
+            "precision mediump float;\n" +
+            "in vec2 v_texCoord;\n" +
+            "in vec2 v_imgCoord;\n" +
+            "uniform sampler2D sTexture;\n" +
+            "out vec4 fragColor;\n" +
+            "void main() {\n" +
+            "  fragColor = texture(sTexture, v_texCoord);\n" +
+            "}\n";
+
+    private final Context context;
+
+    // EGL State
+    private EGLDisplay eglDisplay = EGL14.EGL_NO_DISPLAY;
+    private EGLContext eglContext = EGL14.EGL_NO_CONTEXT;
+    private EGLSurface eglSurface = EGL14.EGL_NO_SURFACE;
+    
+    // Shader Programs
+    private int blitProgram = 0;
+    private int postProgram = 0;
+    
+    // Textures and Framebuffers
+    private int oesTextureId; // Texture ID for the hardware decoder output
+    private int fboTextureId; // Standard 2D texture ID attached to the FBO
+    private int fboId;        // Framebuffer Object ID for the first pass
+    
+    // Surface management
+    private SurfaceTexture surfaceTexture;
+    private Surface decoderSurface;
+    private final float[] transformMatrix = new float[16];
+
+    // Handles for Pass 1 (Blit)
+    private int blit_uSTMatrixHandle;
+    private int blit_aPositionHandle;
+    private int blit_aTexCoordHandle;
+    private int blit_sTextureHandle;
+
+    // Handles for Pass 2 (Custom Shader)
+    private int post_aPositionHandle;
+    private int post_aTexCoordHandle;
+    private int post_sTextureHandle;
+
+    // Full-screen quad vertices (Position X, Y, Texture X, Y)
+    private static final float[] VERTICES = {
+            -1.0f, -1.0f, 0.0f, 0.0f, // Bottom Left
+             1.0f, -1.0f, 1.0f, 0.0f, // Bottom Right
+            -1.0f,  1.0f, 0.0f, 1.0f, // Top Left
+             1.0f,  1.0f, 1.0f, 1.0f, // Top Right
+    };
+    private FloatBuffer vertexBuffer;
+    
+    // Concurrency and synchronization
+    private final Object frameAvailableLock = new Object();
+    private boolean frameAvailable = false;
+    
+    // Resolution information
+    private int streamWidth, streamHeight;
+    private int displayWidth, displayHeight;
+
+    public GlesPassthroughBridge(Context context) {
+        this.context = context;
+        
+        // Allocate direct memory for the vertex buffer
+        vertexBuffer = ByteBuffer.allocateDirect(VERTICES.length * 4)
+                .order(ByteOrder.nativeOrder())
+                .asFloatBuffer();
+        vertexBuffer.put(VERTICES).position(0);
+    }
+
+    /**
+     * Utility method to load a shader from the assets folder.
+     * @param fileName The name of the shader file in assets.
+     * @return The string content of the shader, or null if loading failed.
+     */
+    private String loadAsset(String fileName) {
+        StringBuilder sb = new StringBuilder();
+        try (InputStream is = context.getAssets().open(fileName);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+        } catch (IOException e) {
+            LimeLog.severe(TAG + ": Failed to load asset: " + fileName + " - " + e.getMessage());
+            return null;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Helper method to check for OpenGL errors and log them.
+     * @param op The operation that was just performed.
+     */
+    private void checkGlError(String op) {
+        int error;
+        while ((error = GLES31.glGetError()) != GLES31.GL_NO_ERROR) {
+            LimeLog.severe(TAG + ": " + op + ": glError " + error);
+        }
+    }
+
+    /**
+     * Initializes the EGL context, the shader programs, and the rendering surfaces.
+     * Must be called before any rendering takes place.
+     * 
+     * @param targetSurface The final display surface (e.g., from a SurfaceView).
+     * @param streamWidth The width of the incoming video stream.
+     * @param streamHeight The height of the incoming video stream.
+     */
+    public void initialize(Surface targetSurface, int streamWidth, int streamHeight) {
+        this.streamWidth = streamWidth;
+        this.streamHeight = streamHeight;
+
+        // Initialize EGL Display
+        eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY);
+        int[] version = new int[2];
+        EGL14.eglInitialize(eglDisplay, version, 0, version, 1);
+
+        // Configure EGL for OpenGL ES 3.0+
+        int[] configAttribs = {
+                EGL14.EGL_RENDERABLE_TYPE, EGLExt.EGL_OPENGL_ES3_BIT_KHR,
+                EGL14.EGL_RED_SIZE, 8, EGL14.EGL_GREEN_SIZE, 8, EGL14.EGL_BLUE_SIZE, 8,
+                EGL14.EGL_NONE
+        };
+        EGLConfig[] configs = new EGLConfig[1];
+        int[] numConfigs = new int[1];
+        EGL14.eglChooseConfig(eglDisplay, configAttribs, 0, configs, 0, 1, numConfigs, 0);
+
+        // Create EGL Context
+        int[] contextAttribs = { EGL14.EGL_CONTEXT_CLIENT_VERSION, 3, EGL14.EGL_NONE };
+        eglContext = EGL14.eglCreateContext(eglDisplay, configs[0], EGL14.EGL_NO_CONTEXT, contextAttribs, 0);
+        
+        // Create EGL Surface connected to the target display
+        eglSurface = EGL14.eglCreateWindowSurface(eglDisplay, configs[0], targetSurface, new int[]{EGL14.EGL_NONE}, 0);
+        
+        if (eglSurface == EGL14.EGL_NO_SURFACE) {
+            int error = EGL14.eglGetError();
+            LimeLog.severe(TAG + ": eglCreateWindowSurface failed: " + error);
+            throw new IllegalStateException("eglCreateWindowSurface failed with error " + error);
+        }
+        
+        if (!EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+            int error = EGL14.eglGetError();
+            LimeLog.severe(TAG + ": eglMakeCurrent failed: " + error);
+            throw new IllegalStateException("eglMakeCurrent failed with error " + error);
+        }
+
+        // Disable VSync synchronization inside EGL to avoid adding latency
+        EGL14.eglSwapInterval(eglDisplay, 0);
+
+        // Query the actual dimensions of the display surface
+        int[] queryW = new int[1], queryH = new int[1];
+        EGL14.eglQuerySurface(eglDisplay, eglSurface, EGL14.EGL_WIDTH, queryW, 0);
+        EGL14.eglQuerySurface(eglDisplay, eglSurface, EGL14.EGL_HEIGHT, queryH, 0);
+        this.displayWidth = queryW[0];
+        this.displayHeight = queryH[0];
+
+        // 1. Setup Blit Program (OES -> 2D Texture)
+        blitProgram = createProgram(BLIT_VERTEX_SHADER, BLIT_FRAGMENT_SHADER);
+        blit_uSTMatrixHandle = GLES31.glGetUniformLocation(blitProgram, "uSTMatrix");
+        blit_aPositionHandle = GLES31.glGetAttribLocation(blitProgram, "aPosition");
+        blit_aTexCoordHandle = GLES31.glGetAttribLocation(blitProgram, "aTexCoord");
+        blit_sTextureHandle = GLES31.glGetUniformLocation(blitProgram, "sTexture");
+
+        // 2. Setup Post-Process Program (Custom Shader)
+        setupPostProgram();
+
+        // 3. Generate Textures
+        int[] textures = new int[2];
+        GLES31.glGenTextures(2, textures, 0);
+        oesTextureId = textures[0];
+        fboTextureId = textures[1];
+
+        // Configure OES Texture (used by MediaCodec)
+        GLES31.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, oesTextureId);
+        GLES31.glTexParameterf(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES31.GL_TEXTURE_MIN_FILTER, GLES31.GL_NEAREST);
+        GLES31.glTexParameterf(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES31.GL_TEXTURE_MAG_FILTER, GLES31.GL_NEAREST);
+        GLES31.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES31.GL_TEXTURE_WRAP_S, GLES31.GL_CLAMP_TO_EDGE);
+        GLES31.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES31.GL_TEXTURE_WRAP_T, GLES31.GL_CLAMP_TO_EDGE);
+
+        // Configure Standard 2D Texture (used as FBO color attachment)
+        GLES31.glBindTexture(GLES31.GL_TEXTURE_2D, fboTextureId);
+        GLES31.glTexImage2D(GLES31.GL_TEXTURE_2D, 0, GLES31.GL_RGBA, streamWidth, streamHeight, 0, GLES31.GL_RGBA, GLES31.GL_UNSIGNED_BYTE, null);
+        GLES31.glTexParameteri(GLES31.GL_TEXTURE_2D, GLES31.GL_TEXTURE_MIN_FILTER, GLES31.GL_LINEAR);
+        GLES31.glTexParameteri(GLES31.GL_TEXTURE_2D, GLES31.GL_TEXTURE_MAG_FILTER, GLES31.GL_LINEAR);
+        GLES31.glTexParameteri(GLES31.GL_TEXTURE_2D, GLES31.GL_TEXTURE_WRAP_S, GLES31.GL_CLAMP_TO_EDGE);
+        GLES31.glTexParameteri(GLES31.GL_TEXTURE_2D, GLES31.GL_TEXTURE_WRAP_T, GLES31.GL_CLAMP_TO_EDGE);
+
+        // 4. Setup Framebuffer Object (FBO) for Pass 1
+        int[] fbos = new int[1];
+        GLES31.glGenFramebuffers(1, fbos, 0);
+        fboId = fbos[0];
+        GLES31.glBindFramebuffer(GLES31.GL_FRAMEBUFFER, fboId);
+        GLES31.glFramebufferTexture2D(GLES31.GL_FRAMEBUFFER, GLES31.GL_COLOR_ATTACHMENT0, GLES31.GL_TEXTURE_2D, fboTextureId, 0);
+        
+        // Ensure the Framebuffer is complete
+        int status = GLES31.glCheckFramebufferStatus(GLES31.GL_FRAMEBUFFER);
+        if (status != GLES31.GL_FRAMEBUFFER_COMPLETE) {
+            LimeLog.severe(TAG + ": Framebuffer incomplete: " + status);
+        }
+        // Unbind FBO
+        GLES31.glBindFramebuffer(GLES31.GL_FRAMEBUFFER, 0);
+
+        // Create SurfaceTexture to receive hardware decoded frames
+        surfaceTexture = new SurfaceTexture(oesTextureId);
+        surfaceTexture.setOnFrameAvailableListener(this);
+        decoderSurface = new Surface(surfaceTexture);
+        
+        // IMPORTANT: Unbind context so it can be picked up by the rendering thread!
+        EGL14.eglMakeCurrent(eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_CONTEXT);
+
+        LimeLog.info(TAG + ": GLES 3.1 2-Pass Bridge initialized: Stream=" + streamWidth + "x" + streamHeight + " Display=" + displayWidth + "x" + displayHeight);
+    }
+
+    private void setupPostProgram() {
+        if (postProgram != 0) {
+            GLES31.glDeleteProgram(postProgram);
+            postProgram = 0;
+        }
+
+        String postSource = loadAsset("sgsr1_shader_mobile_edge_direction.frag");
+
+        // Define stream size resolutions constants directly into the GLSL Code at compile time
+        // This leverages "Constant Folding", an optimization where the GPU calculates all
+        // resolutions and math functions explicitly at compile time instead of per-frame.
+        String compileTimeDefines = "\n#define SRC_W " + streamWidth + ".0\n" +
+                                    "#define SRC_H " + streamHeight + ".0\n" +
+                                    "#define INV_SRC_W " + (1.0f / streamWidth) + "\n" +
+                                    "#define INV_SRC_H " + (1.0f / streamHeight) + "\n";
+
+        if (postSource == null || postSource.trim().isEmpty()) {
+            LimeLog.warning(TAG + ": sgsr1_shader_mobile_edge_direction.frag is missing or empty. Using fallback shader.");
+            postSource = FALLBACK_POST_FRAGMENT_SHADER;
+        } else {
+            // Inject the dynamic resolutions into the source code of the Fragment Shader.
+            postSource = postSource.replaceFirst("(#version 310 es)", "$1" + compileTimeDefines);
+        }
+
+        // Vertex shader for the final post-processing pass
+        // It has been highly optimized to pre-calculate image coordinates across the 4 corners
+        // of the vertex, allowing the hardware interpolator to naturally pass the coordinate
+        // per-fragment down into the pipeline for completely free calculations.
+        String postVertexShader =
+                "#version 310 es\n" +
+                compileTimeDefines +
+                "in vec4 aPosition;\n" +
+                "in vec4 aTexCoord;\n" +
+                "out vec2 v_texCoord;\n" +
+                "out vec2 v_imgCoord;\n" +
+                "void main() {\n" +
+                "  gl_Position = aPosition;\n" +
+                "  v_texCoord = aTexCoord.xy;\n" +
+                "  v_imgCoord = (aTexCoord.xy * vec2(SRC_W, SRC_H)) + vec2(-0.5, 0.5);\n" +
+                "}\n";
+
+        postProgram = createProgram(postVertexShader, postSource);
+        post_aPositionHandle = GLES31.glGetAttribLocation(postProgram, "aPosition");
+        post_aTexCoordHandle = GLES31.glGetAttribLocation(postProgram, "aTexCoord");
+        
+        // Find sampler uniform (supports different naming conventions for flexibility)
+        post_sTextureHandle = GLES31.glGetUniformLocation(postProgram, "sTexture");
+        if (post_sTextureHandle == -1) post_sTextureHandle = GLES31.glGetUniformLocation(postProgram, "uTexture");
+        if (post_sTextureHandle == -1) post_sTextureHandle = GLES31.glGetUniformLocation(postProgram, "Source");
+        if (post_sTextureHandle == -1) post_sTextureHandle = GLES31.glGetUniformLocation(postProgram, "ps0"); // Used by SGSR1
+    }
+
+    /**
+     * @return The surface to pass to the MediaCodec decoder.
+     */
+    public Surface getDecoderSurface() {
+        return decoderSurface;
+    }
+
+    /**
+     * Callback fired by Android when a new frame is decoded and ready to be processed.
+     */
+    @Override
+    public void onFrameAvailable(SurfaceTexture surfaceTexture) {
+        synchronized (frameAvailableLock) {
+            frameAvailable = true;
+            frameAvailableLock.notifyAll(); // Wake up the rendering thread
+        }
+    }
+
+    /**
+     * Renders a single frame. Should be called repeatedly from a dedicated rendering thread.
+     * 
+     * @param presentationTimeNanos The presentation time for the current frame.
+     */
+    public void renderFrame(long presentationTimeNanos) {
+        if (eglDisplay == EGL14.EGL_NO_DISPLAY) return;
+
+        // Wait for a new frame to be available from the decoder
+        synchronized (frameAvailableLock) {
+            long startTime = System.currentTimeMillis();
+            while (!frameAvailable) {
+                try {
+                    frameAvailableLock.wait(50);
+                    // Timeout after 50ms to prevent deadlocks
+                    if (System.currentTimeMillis() - startTime > 50) break;
+                } catch (InterruptedException e) { return; }
+            }
+            frameAvailable = false;
+        }
+
+        // Ensure the EGL context is current on the rendering thread
+        if (!EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+            LimeLog.severe(TAG + ": eglMakeCurrent failed in renderFrame");
+            return;
+        }
+        
+        // Consume the new frame from the decoder
+        surfaceTexture.updateTexImage();
+        surfaceTexture.getTransformMatrix(transformMatrix);
+
+        // ==========================================================
+        // PASS 1: Decode to 2D Texture (FBO)
+        // ==========================================================
+        
+        // Bind the FBO to render off-screen
+        GLES31.glBindFramebuffer(GLES31.GL_FRAMEBUFFER, fboId);
+        GLES31.glViewport(0, 0, streamWidth, streamHeight);
+        GLES31.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        GLES31.glClear(GLES31.GL_COLOR_BUFFER_BIT);
+
+        GLES31.glUseProgram(blitProgram);
+        
+        // Pass the SurfaceTexture transform matrix to correct orientation
+        if (blit_uSTMatrixHandle >= 0) GLES31.glUniformMatrix4fv(blit_uSTMatrixHandle, 1, false, transformMatrix, 0);
+        if (blit_sTextureHandle >= 0) GLES31.glUniform1i(blit_sTextureHandle, 0);
+
+        // Bind the hardware OES texture
+        GLES31.glActiveTexture(GLES31.GL_TEXTURE0);
+        GLES31.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, oesTextureId);
+        
+        // Draw a full-screen quad to execute the blit
+        drawQuad(blit_aPositionHandle, blit_aTexCoordHandle);
+
+        // ==========================================================
+        // PASS 2: Post-Process to Screen
+        // ==========================================================
+        
+        // Bind the default framebuffer to render to the display
+        GLES31.glBindFramebuffer(GLES31.GL_FRAMEBUFFER, 0);
+        GLES31.glViewport(0, 0, displayWidth, displayHeight);
+        GLES31.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        GLES31.glClear(GLES31.GL_COLOR_BUFFER_BIT);
+
+        GLES31.glUseProgram(postProgram);
+
+        if (post_sTextureHandle >= 0) GLES31.glUniform1i(post_sTextureHandle, 0);
+
+        // Bind the 2D texture populated during Pass 1
+        GLES31.glActiveTexture(GLES31.GL_TEXTURE0);
+        GLES31.glBindTexture(GLES31.GL_TEXTURE_2D, fboTextureId);
+
+        // Draw the final post-processed image
+        drawQuad(post_aPositionHandle, post_aTexCoordHandle);
+        
+        // Present the frame to the display
+        EGLExt.eglPresentationTimeANDROID(eglDisplay, eglSurface, presentationTimeNanos);
+        EGL14.eglSwapBuffers(eglDisplay, eglSurface);
+    }
+
+    /**
+     * Draws a standard full-screen quad using the allocated vertex buffer.
+     * 
+     * @param posHandle The GL attribute handle for vertex positions.
+     * @param texHandle The GL attribute handle for texture coordinates.
+     */
+    private void drawQuad(int posHandle, int texHandle) {
+        if (posHandle >= 0) {
+            GLES31.glEnableVertexAttribArray(posHandle);
+            vertexBuffer.position(0);
+            // Each vertex is 4 floats: [PosX, PosY, TexU, TexV]. Stride = 4 * 4 bytes = 16.
+            GLES31.glVertexAttribPointer(posHandle, 2, GLES31.GL_FLOAT, false, 16, vertexBuffer);
+        }
+        if (texHandle >= 0) {
+            GLES31.glEnableVertexAttribArray(texHandle);
+            vertexBuffer.position(2); // Offset to start at TexU
+            GLES31.glVertexAttribPointer(texHandle, 2, GLES31.GL_FLOAT, false, 16, vertexBuffer);
+        }
+
+        // Execute the draw call
+        GLES31.glDrawArrays(GLES31.GL_TRIANGLE_STRIP, 0, 4);
+
+        // Cleanup attribute bindings
+        if (posHandle >= 0) GLES31.glDisableVertexAttribArray(posHandle);
+        if (texHandle >= 0) GLES31.glDisableVertexAttribArray(texHandle);
+    }
+
+    /**
+     * Compiles and links a complete GLSL program from vertex and fragment shader source code.
+     */
+    private int createProgram(String vertexSource, String fragmentSource) {
+        int vertexShader = loadShader(GLES31.GL_VERTEX_SHADER, vertexSource);
+        if (vertexShader == 0) return 0;
+        int fragmentShader = loadShader(GLES31.GL_FRAGMENT_SHADER, fragmentSource);
+        if (fragmentShader == 0) return 0;
+        
+        int program = GLES31.glCreateProgram();
+        if (program != 0) {
+            GLES31.glAttachShader(program, vertexShader);
+            GLES31.glAttachShader(program, fragmentShader);
+            GLES31.glLinkProgram(program);
+            
+            int[] linkStatus = new int[1];
+            GLES31.glGetProgramiv(program, GLES31.GL_LINK_STATUS, linkStatus, 0);
+            if (linkStatus[0] != GLES31.GL_TRUE) {
+                LimeLog.severe(TAG + ": Could not link program: " + GLES31.glGetProgramInfoLog(program));
+                GLES31.glDeleteProgram(program);
+                program = 0;
+            }
+        }
+        return program;
+    }
+
+    /**
+     * Compiles a single shader object.
+     */
+    private int loadShader(int type, String shaderCode) {
+        int shader = GLES31.glCreateShader(type);
+        GLES31.glShaderSource(shader, shaderCode);
+        GLES31.glCompileShader(shader);
+        
+        int[] compiled = new int[1];
+        GLES31.glGetShaderiv(shader, GLES31.GL_COMPILE_STATUS, compiled, 0);
+        if (compiled[0] == 0) {
+            LimeLog.severe(TAG + ": Could not compile shader " + type + ": " + GLES31.glGetShaderInfoLog(shader));
+            GLES31.glDeleteShader(shader);
+            shader = 0;
+        }
+        return shader;
+    }
+
+    /**
+     * Frees all allocated OpenGL and EGL resources.
+     */
+    public void release() {
+        if (eglDisplay != EGL14.EGL_NO_DISPLAY) {
+            EGL14.eglMakeCurrent(eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_CONTEXT);
+            if (eglSurface != EGL14.EGL_NO_SURFACE) {
+                EGL14.eglDestroySurface(eglDisplay, eglSurface);
+            }
+            EGL14.eglDestroyContext(eglDisplay, eglContext);
+            EGL14.eglReleaseThread();
+            EGL14.eglTerminate(eglDisplay);
+        }
+        if (surfaceTexture != null) {
+            surfaceTexture.release();
+        }
+        if (decoderSurface != null) {
+            decoderSurface.release();
+        }
+        eglDisplay = EGL14.EGL_NO_DISPLAY;
+        eglContext = EGL14.EGL_NO_CONTEXT;
+        eglSurface = EGL14.EGL_NO_SURFACE;
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -35,6 +35,7 @@ import android.os.Process;
 import android.os.SystemClock;
 import android.util.Range;
 import android.view.Choreographer;
+import android.view.Surface;
 import android.view.SurfaceHolder;
 
 public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements Choreographer.FrameCallback {
@@ -78,6 +79,9 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     private String glRenderer;
     private boolean foreground = true;
     private PerfOverlayListener perfListener;
+
+    private GlesPassthroughBridge glesBridge;
+    private float videoSrUpscaleRatio;
 
     private static final int CR_MAX_TRIES = 10;
     private static final int CR_RECOVERY_TYPE_NONE = 0;
@@ -537,7 +541,20 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
         LimeLog.info("Configuring with format: "+format);
 
-        videoDecoder.configure(format, renderTarget.getSurface(), null, 0);
+        if (prefs.videoSr) {
+            // SGSR1 Upscaling
+            glesBridge = new GlesPassthroughBridge(this.context);
+            glesBridge.initialize(renderTarget.getSurface(), initialWidth, initialHeight);
+            Surface decoderSurface = glesBridge.getDecoderSurface();
+
+            videoDecoder.configure(format, decoderSurface, null, 0);
+
+            this.videoSrUpscaleRatio = renderTarget.getSurfaceFrame().width() / (float)initialWidth;
+        } else {
+            videoDecoder.configure(format, renderTarget.getSurface(), null, 0);
+
+            this.videoSrUpscaleRatio = 1.0f;
+        }
 
         configuredFormat = format;
 
@@ -589,6 +606,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
             if (!configured && videoDecoder != null) {
                 videoDecoder.release();
                 videoDecoder = null;
+            }
+            if (!configured && glesBridge != null) {
+                glesBridge.release();
+                glesBridge = null;
             }
         }
         return configured;
@@ -761,6 +782,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     LimeLog.warning("Trying to restart decoder after CodecException");
                     try {
                         videoDecoder.stop();
+                        if (glesBridge != null) {
+                            glesBridge.release();
+                            glesBridge = null;
+                        }
                         configureAndStartDecoder(configuredFormat);
                         codecRecoveryType.set(CR_RECOVERY_TYPE_NONE);
                     } catch (IllegalArgumentException e) {
@@ -784,6 +809,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     LimeLog.warning("Trying to reset decoder after CodecException");
                     try {
                         videoDecoder.reset();
+                        if (glesBridge != null) {
+                            glesBridge.release();
+                            glesBridge = null;
+                        }
                         configureAndStartDecoder(configuredFormat);
                         codecRecoveryType.set(CR_RECOVERY_TYPE_NONE);
                     } catch (IllegalArgumentException e) {
@@ -807,6 +836,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     videoDecoder.release();
 
                     try {
+                        if (glesBridge != null) {
+                            glesBridge.release();
+                            glesBridge = null;
+                        }
                         int err = initializeDecoder(true);
                         if (err != 0) {
                             throw new IllegalStateException("Decoder reset failed: " + err);
@@ -1001,6 +1034,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                         videoDecoder.releaseOutputBuffer(nextOutputBuffer, true);
                     }
 
+                    if (prefs.videoSr && glesBridge != null) {
+                        glesBridge.renderFrame(frameTimeNanos);
+                    }
+
                     lastRenderedFrameTimeNanos = frameTimeNanos;
                     activeWindowVideoStats.totalFramesRendered++;
                 } catch (IllegalStateException ignored) {
@@ -1092,6 +1129,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                     else {
                                         videoDecoder.releaseOutputBuffer(lastIndex, true);
                                     }
+                                }
+
+                                if (prefs.videoSr && glesBridge != null) {
+                                    glesBridge.renderFrame(0);
                                 }
 
                                 activeWindowVideoStats.totalFramesRendered++;
@@ -1298,6 +1339,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
     @Override
     public void cleanup() {
+        if (glesBridge != null) {
+            glesBridge.release();
+            glesBridge = null;
+        }
         videoDecoder.release();
     }
 
@@ -1445,6 +1490,11 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                 StringBuilder sb = new StringBuilder();
                 sb.append(context.getString(R.string.perf_overlay_streamdetails, initialWidth + "x" + initialHeight, fps.totalFps)).append('\n');
                 sb.append(context.getString(R.string.perf_overlay_decoder, decoder)).append('\n');
+                // Add the video enhancement line if SR is enabled
+                if (prefs.videoSr) {
+                    // Pre-calculated ratio during decoder configuration
+                    sb.append(context.getString(R.string.perf_overlay_video_enhancement, videoSrUpscaleRatio)).append('\n');
+                }
                 sb.append(context.getString(R.string.perf_overlay_incomingfps, fps.receivedFps)).append('\n');
                 sb.append(context.getString(R.string.perf_overlay_renderingfps, fps.renderedFps)).append('\n');
                 sb.append(context.getString(R.string.perf_overlay_netdrops,

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -68,6 +68,7 @@ public class PreferenceConfiguration {
     private static final String GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING = "checkbox_gamepad_touchpad_as_mouse";
     private static final String GAMEPAD_MOTION_SENSORS_PREF_STRING = "checkbox_gamepad_motion_sensors";
     private static final String GAMEPAD_MOTION_FALLBACK_PREF_STRING = "checkbox_gamepad_motion_fallback";
+    private static final String VIDEO_SR_PREF_STRING = "checkbox_video_sr";
 
     static final String DEFAULT_RESOLUTION = "1280x720";
     static final String DEFAULT_FPS = "60";
@@ -108,6 +109,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE = false;
     private static final boolean DEFAULT_GAMEPAD_MOTION_SENSORS = true;
     private static final boolean DEFAULT_GAMEPAD_MOTION_FALLBACK = false;
+    private static final boolean DEFAULT_VIDEO_SR = false;
 
     public static final int FRAME_PACING_MIN_LATENCY = 0;
     public static final int FRAME_PACING_BALANCED = 1;
@@ -155,6 +157,7 @@ public class PreferenceConfiguration {
     public boolean gamepadMotionSensors;
     public boolean gamepadTouchpadAsMouse;
     public boolean gamepadMotionSensorsFallbackToDevice;
+    public boolean videoSr;
 
     public static boolean isNativeResolution(int width, int height) {
         // It's not a native resolution if it matches an existing resolution option
@@ -601,6 +604,7 @@ public class PreferenceConfiguration {
         config.gamepadTouchpadAsMouse = prefs.getBoolean(GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING, DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE);
         config.gamepadMotionSensors = prefs.getBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, DEFAULT_GAMEPAD_MOTION_SENSORS);
         config.gamepadMotionSensorsFallbackToDevice = prefs.getBoolean(GAMEPAD_MOTION_FALLBACK_PREF_STRING, DEFAULT_GAMEPAD_MOTION_FALLBACK);
+        config.videoSr = prefs.getBoolean(VIDEO_SR_PREF_STRING, DEFAULT_VIDEO_SR);
 
         return config;
     }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.java
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.java
@@ -1,8 +1,10 @@
 package com.limelight.preferences;
 
+import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ConfigurationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.media.MediaCodecInfo;
@@ -277,6 +279,21 @@ public class StreamSettings extends Activity {
             addPreferencesFromResource(R.xml.preferences);
             PreferenceScreen screen = getPreferenceScreen();
 
+            // Check for GLES 3.1 support (Required for advanced upscaling features like textureGather)
+            ActivityManager activityManager = (ActivityManager) getActivity().getSystemService(Context.ACTIVITY_SERVICE);
+            ConfigurationInfo configurationInfo = activityManager.getDeviceConfigurationInfo();
+            boolean supportsGles31 = configurationInfo.reqGlEsVersion >= 0x30001;
+
+            // Handle Video Super Resolution checkbox
+            CheckBoxPreference videoSrPref = (CheckBoxPreference) findPreference("checkbox_video_sr");
+            if (videoSrPref != null) {
+                if (!supportsGles31) {
+                    // Disable and gray out if GLES 3.1 is not available
+                    videoSrPref.setEnabled(false);
+                    videoSrPref.setSummary(videoSrPref.getSummary() + " (Requires GLES 3.1)");
+                }
+            }
+
             // hide on-screen controls category on non touch screen devices
             if (!getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)) {
                 PreferenceCategory category =
@@ -492,7 +509,7 @@ public class StreamSettings extends Activity {
                             @Override
                             public void run() {
                                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(SettingsFragment.this.getActivity());
-                                setValue(PreferenceConfiguration.RESOLUTION_PREF_STRING, PreferenceConfiguration.RES_1080P);
+                                setValue(PreferenceConfiguration.RESOLUTION_PREF_STRING, PreferenceConfiguration.RES_1440P);
                                 resetBitrateToDefault(prefs, null, null);
                             }
                         });

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -140,4 +140,7 @@
     <string name="title_checkbox_touchscreen_trackpad">Използване на сензорния екран като тракпад</string>
     <string name="title_checkbox_multi_controller">Автоматично откриване на наличен контролер</string>
     <string name="summary_checkbox_multi_controller">Премахването на отметката от тази опция принуждава контролер винаги да присъства</string>
+    <string name="perf_overlay_video_enhancement">Подобряване на видеото: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Видео супер резолюция</string>
+    <string name="summary_video_sr">Използвайте хардуерно ускорение за подобряване на яснотата на изображението</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -247,4 +247,7 @@
     <string name="title_frame_pacing">Frame pacing videa</string>
     <string name="summary_frame_pacing">Zvolte, jak vyvážit zpoždění videa a jeho plynulost</string>
     <string name="pacing_latency">Preferovat nejnižší zpoždění</string>
+    <string name="perf_overlay_video_enhancement">Vylepšení videa: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Super rozlišení videa</string>
+    <string name="summary_video_sr">Využijte hardwarovou akceleraci ke zvýšení čistoty obrazu</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -275,4 +275,7 @@
     <string name="analogscroll_none">Keine (beide Sticks bewegen die Maus)</string>
     <string name="analogscroll_right">Rechter Analogstick</string>
     <string name="analogscroll_left">Linker Analogstick</string>
+    <string name="perf_overlay_video_enhancement">Video-Verbesserung: (x%1$.2f) SGSR1</string>
+    <string name="title_video_sr">Video-Super-Resolution</string>
+    <string name="summary_video_sr">Hardwarebeschleunigung nutzen, um die Bildklarheit zu verbessern</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -212,4 +212,7 @@
 \nΔοκιμάστε να απενεργοποιήσετε τη λειτουργία HDR, να αλλάξετε την ανάλυση ροής ή να αλλάξετε την ανάλυση οθόνης του υπολογιστή φιλοξενίας.</string>
     <string name="pcview_menu_eol">Λήξη Υποστήριξης NVIDA GameStream</string>
     <string name="pair_pairing_help">Εάν ο υπολογιστής οικοδεσπότης χρησιμοποιεί το Sunshine, πλοηγηθείτε στην διαδικτυακή διεπαφή χρήστη του Sunshine για να εισάγετε το PIN.</string>
+    <string name="perf_overlay_video_enhancement">Βελτίωση βίντεο: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Super Resolution Βίντεο</string>
+    <string name="summary_video_sr">Αξιοποιήστε την επιτάχυνση υλικού για να βελτιώσετε την ευκρίνεια της εικόνας</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -287,4 +287,7 @@
     <string name="title_seekbar_vibrate_fallback_strength">Ajustar la intensidad del ruido emulado</string>
     <string name="summary_seekbar_vibrate_fallback_strength">Amplifica o reduce la intensidad de la vibración de tu dispositivo</string>
     <string name="suffix_seekbar_vibrate_fallback_strength">%</string>
+    <string name="perf_overlay_video_enhancement">Mejora de video: (x%1$.2f) SGSR1</string>
+    <string name="title_video_sr">Súper resolución de vídeo</string>
+    <string name="summary_video_sr">Aproveche la aceleración de hardware para mejorar la claridad de la imagen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -285,4 +285,7 @@
     <string name="title_seekbar_vibrate_fallback_strength">Ajuster l\'intensité de la vibration émulée</string>
     <string name="summary_seekbar_vibrate_fallback_strength">Amplifie ou réduit l\'intensité de la vibration sur votre appareil</string>
     <string name="suffix_seekbar_vibrate_fallback_strength">%</string>
+    <string name="perf_overlay_video_enhancement">Amélioration vidéo : (x%1$.2f) SGSR1</string>
+    <string name="title_video_sr">Super Résolution Vidéo</string>
+    <string name="summary_video_sr">Utiliser l\'accélération matérielle pour améliorer la clarté de l\'image</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -259,4 +259,7 @@
     <string name="resolution_prefix_native_landscape">(Tájkép)</string>
     <string name="perf_overlay_hostprocessinglatency">Host feldolgozási késleltetés min/max/átlag: %1$.1f/%2$.1f/%3$.1f ms</string>
     <string name="pacing_latency">A legalacsonyabb késleltetés előnyben részesítése</string>
+    <string name="perf_overlay_video_enhancement">Videó javítása: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Videó szuperfelbontás</string>
+    <string name="summary_video_sr">Hardveres gyorsítás használata a kép tisztaságának javítása érdekében</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -211,4 +211,7 @@
     <string name="title_checkbox_enable_pip">Aktifkan mode pengamat Gambar-dalam-Gambar</string>
     <string name="summary_language_list">Bahasa yang digunakan untuk Moonlight</string>
     <string name="summary_checkbox_enable_sops">Izinkan GFE mengubah setelan game untuk streaming yang optimal</string>
+    <string name="perf_overlay_video_enhancement">Peningkatan Video: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Super Resolusi Video</string>
+    <string name="summary_video_sr">Manfaatkan akselerasi perangkat keras untuk meningkatkan kejelasan gambar</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -279,4 +279,7 @@
     <string name="pair_pairing_help">Se il tuo PC host sta eseguendo Sunshine, vai nella pagina web locale di Sunshine ed inserisci il PIN.</string>
     <string name="title_checkbox_gamepad_touchpad_as_mouse">Controlla sempre il mouse col touchpad</string>
     <string name="perf_overlay_hostprocessinglatency">Latenza di codifica da parte dell\'host min/max/average: %1$.1f/%2$.1f/%3$.1f ms</string>
+    <string name="perf_overlay_video_enhancement">Miglioramento video: (x%1$.2f) SGSR1</string>
+    <string name="title_video_sr">Super risoluzione video</string>
+    <string name="summary_video_sr">Sfrutta l\'accelerazione hardware per migliorare la nitidezza dell\'immagine</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -152,4 +152,7 @@
     <string name="title_checkbox_enable_audiofx">הפעל תמיכה באקולייזר</string>
     <string name="category_input_settings">הגדרות קלט</string>
     <string name="title_checkbox_touchscreen_trackpad">השתמש במסך מגע כמשטח מגע</string>
+    <string name="perf_overlay_video_enhancement">שיפור וידאו: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">סופר-רזולוציה בווידאו</string>
+    <string name="summary_video_sr">השתמש בהאצת חומרה כדי לשפר את בהירות התמונה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -137,4 +137,7 @@
     <string name="nettest_title_done">ネットワークテスト終了</string>
     <string name="pcview_menu_details">詳細を表示</string>
     <string name="nettest_title_waiting">ネットワーク接続テスト中</string>
+    <string name="perf_overlay_video_enhancement">ビデオ拡張: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">ビデオ超解像</string>
+    <string name="summary_video_sr">ハードウェアアクセラレーションを活用して画像の鮮明さを向上させる</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -278,4 +278,7 @@
     <string name="summary_checkbox_gamepad_motion_fallback">연결된 컨트롤러 또는 기기의 Android 버전에서 컨트롤러 센서가 지원되지 않는 경우 장치에 내장된 모션 센서를 사용합니다.
 \n참고: 이 옵션을 활성화하면 사용 중인 컨트롤러가 호스트에서 PlayStation 컨트롤러로 나타날 수 있습니다.</string>
     <string name="title_checkbox_gamepad_motion_fallback">컨트롤러의 모션 센서 에뮬레이션 지원</string>
+    <string name="perf_overlay_video_enhancement">비디오 향상: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">비디오 초해상도</string>
+    <string name="summary_video_sr">하드웨어 가속을 사용하여 이미지 선명도 향상</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -207,4 +207,7 @@
     <string name="resolution_prefix_native_fullscreen">Systemspesifikk fullskjerm</string>
     <string name="perf_overlay_netlatency">Gjennomsnittlig nettverksforsinkelse: %1$d ms (variasjon: %2$d ms)</string>
     <string name="perf_overlay_streamdetails">Videostrøm: %1$s %2$.2f BPS</string>
+    <string name="perf_overlay_video_enhancement">Video-forbedring: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Video Superoppløsning</string>
+    <string name="summary_video_sr">Bruk maskinvareakselerasjon for å forbedre bildeklarheten</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -223,4 +223,7 @@
     <string name="applist_menu_tv_channel">Toevoegen aan Kanaal</string>
     <!-- Array strings -->
     <string name="videoformat_hevcalways">Gebruik HEVC altijd (mogelijkheid tot crashes)</string>
+    <string name="perf_overlay_video_enhancement">Video-verbetering: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Video Superresolutie</string>
+    <string name="summary_video_sr">Gebruik hardwareversnelling om de helderheid van het beeld te verbeteren</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -272,4 +272,7 @@
     <string name="videoformat_auto">Automatycznie (zalecane)</string>
     <string name="videoformat_av1always">Preferowany AV1 (eksperymentalny)</string>
     <string name="summary_setup_guide">Wyświetl instrukcje, jak skonfigurować komputer do gier do streamowania</string>
+    <string name="perf_overlay_video_enhancement">Ulepszenie wideo: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Super rozdzielczość wideo</string>
+    <string name="summary_video_sr">Wykorzystaj akcelerację sprzętową, aby poprawić klarowność obrazu</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -254,4 +254,7 @@
     <string name="analogscroll_left">Stick analógico esquerdo</string>
     <string name="title_analog_scrolling">Usar um stick analógico para fazer scroll</string>
     <string name="summary_analog_scrolling">Selecciona um stick analógico para fazer scroll quando a emulação de rato está ativada</string>
+    <string name="perf_overlay_video_enhancement">Melhoria de vídeo: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Super-resolução de vídeo</string>
+    <string name="summary_video_sr">Aproveite a aceleração de hardware para melhorar a clareza da imagem</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -254,4 +254,7 @@
     <string name="analogscroll_left">Stick analógico esquerdo</string>
     <string name="title_analog_scrolling">Usar um stick analógico para fazer scroll</string>
     <string name="summary_analog_scrolling">Selecciona um stick analógico para fazer scroll quando a emulação de rato está ativada</string>
+    <string name="perf_overlay_video_enhancement">Melhoria de vídeo: (x%1$.2f) SGSR1</string>
+    <string name="title_video_sr">Super-resolução de vídeo</string>
+    <string name="summary_video_sr">Aproveite a aceleração de hardware para melhorar a clareza da imagem</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -178,4 +178,7 @@
     <string name="audioconf_51surround">Sunet Surround 5.1</string>
     <string name="audioconf_71surround">Sunet Surround 7.1</string>
     <string name="videoformat_hevcalways">Folosește HEVC mereu (se poate bloca)</string>
+    <string name="perf_overlay_video_enhancement">Îmbunătățire video: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Super rezoluție video</string>
+    <string name="summary_video_sr">Utilizați accelerarea hardware pentru a îmbunătăți claritatea imaginii</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -254,4 +254,7 @@
     <string name="title_frame_pacing">Скорость вывода/отрисовки кадра</string>
     <string name="pacing_balanced_alt">Сбалансированно с лимитом FPS</string>
     <string name="resolution_480p">480p</string>
+    <string name="perf_overlay_video_enhancement">Улучшение видео: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Супер-разрешение видео</string>
+    <string name="summary_video_sr">Использование аппаратного ускорения для улучшения четкости изображения</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -272,4 +272,7 @@
     <string name="analogscroll_right">Höger analogspak</string>
     <string name="suffix_seekbar_vibrate_fallback_strength">%</string>
     <string name="title_analog_scrolling">Använd en analog spak för att bläddra</string>
+    <string name="perf_overlay_video_enhancement">Videoförbättring: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Video-superupplösning</string>
+    <string name="summary_video_sr">Använd hårdvaruacceleration för att förbättra bildskärpan</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -173,4 +173,7 @@
     <string name="summary_checkbox_usb_bind_all">Yerel Xbox oyun kumandası desteği mevcut olsa bile desteklenen tüm oyun kumandaları için Moonlight\'ın USB sürücüsünü kullan</string>
     <string name="summary_checkbox_flip_face_buttons">Oyun kumandaları ve ekran kontrolleri için A/B ve X/Y yüz düğmelerini değiştirir</string>
     <string name="summary_checkbox_absolute_mouse_mode">Bu fare hızlandırmanın uzak masaüstü kullanımı için daha doğal davranmasını sağlayabilir, ancak birçok oyunla uyumsuzdur.</string>
+    <string name="perf_overlay_video_enhancement">Video İyileştirme: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Video Süper Çözünürlük</string>
+    <string name="summary_video_sr">Görüntü netliğini artırmak için donanım hızlandırmasından yararlanın</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -283,4 +283,7 @@
     <string name="toast_controller_type_changed">Тип геймпада може бути змінений через емуляцію датчика руху</string>
     <string name="pcview_menu_eol">Закриття сервісів NVIDIA GameStream</string>
     <string name="perf_overlay_hostprocessinglatency">Затримка обробки хостом мін./макс./середня: %1$.1f/%2$.1f/%3$.1f мс</string>
+    <string name="perf_overlay_video_enhancement">Покращення відео: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Супер-роздільна здатність відео</string>
+    <string name="summary_video_sr">Використовуйте апаратне прискорення для покращення чіткості зображення</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -233,4 +233,7 @@
     <string name="title_checkbox_enable_audiofx">Hỗ trợ bộ cân bằng của hệ thống</string>
     <string name="summary_checkbox_enable_audiofx">Cho phép hiệu ứng âm thanh hoạt động khi stream, nhưng có thể tăng độ trễ âm thanh</string>
     <string name="resolution_prefix_native_portrait">(Dọc)</string>
+    <string name="perf_overlay_video_enhancement">Cải thiện video: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">Siêu độ phân giải video</string>
+    <string name="summary_video_sr">Tận dụng tăng tốc phần cứng để cải thiện độ rõ nét của hình ảnh</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -284,4 +284,7 @@
     <string name="summary_analog_scrolling">在鼠标模式下选择用哪个摇杆控制鼠标移动</string>
     <string name="summary_seekbar_vibrate_fallback_strength">增强或减弱设备的震动强度</string>
     <string name="analogscroll_none">默认 (两个摇杆都控制鼠标)</string>
+    <string name="perf_overlay_video_enhancement">视频增强: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">视频超分辨率</string>
+    <string name="summary_video_sr">利用硬件加速提高图像清晰度</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -276,4 +276,7 @@
     <string name="summary_checkbox_gamepad_motion_fallback">如果您連線的手把或 Android 版本不支援手把感測器，請使用裝置內建的動態感測器。
 \n注意：啟用此選項可能會導致您的手把在主機被辨識為 PlayStation 控制器。</string>
     <string name="title_checkbox_gamepad_motion_fallback">模擬手把動態感測器支援</string>
+    <string name="perf_overlay_video_enhancement">視訊增強: (x%1$.2f) Shader SGSR1</string>
+    <string name="title_video_sr">視訊超解析度</string>
+    <string name="summary_video_sr">利用硬體加速提高圖像清晰度</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="poor_connection_msg">Poor connection to PC</string>
     <string name="perf_overlay_streamdetails">Video stream: %1$s %2$.2f FPS</string>
     <string name="perf_overlay_decoder">Decoder: %1$s</string>
+    <string name="perf_overlay_video_enhancement">Video Enhancement: (x%1$.2f) Shader SGSR1</string>
     <string name="perf_overlay_incomingfps">Incoming frame rate from network: %1$.2f FPS</string>
     <string name="perf_overlay_renderingfps">Rendering frame rate: %1$.2f FPS</string>
     <string name="perf_overlay_hostprocessinglatency">Host processing latency min/max/average: %1$.1f/%2$.1f/%3$.1f ms</string>
@@ -294,6 +295,9 @@
     <string name="pacing_balanced">Balanced</string>
     <string name="pacing_balanced_alt">Balanced with FPS limit</string>
     <string name="pacing_smoothness">Prefer smoothest video (may significantly increase latency)</string>
+
+    <string name="title_video_sr">Video Super Resolution</string>
+    <string name="summary_video_sr">Leverage hardware acceleration to improve picture clarity</string>
 
     <string name="title_analog_scrolling">Use an analog stick to scroll</string>
     <string name="summary_analog_scrolling">Select an analog stick to scroll when in mouse emulation mode</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -37,6 +37,11 @@
             android:summary="@string/summary_frame_pacing"
             android:defaultValue="latency" />
         <CheckBoxPreference
+            android:key="checkbox_video_sr"
+            android:title="@string/title_video_sr"
+            android:summary="@string/summary_video_sr"
+            android:defaultValue="false" />
+        <CheckBoxPreference
             android:key="checkbox_stretch_video"
             android:title="@string/title_checkbox_stretch_video"
             android:defaultValue="false" />


### PR DESCRIPTION
## Video Super Resolution (VSR) for Moonlight Android

Video Super Resolution (VSR) brings to video what DLSS/FSR bring to real-time 3D rendering.

This PR introduces high-quality spatial upscaling on Android using a highly optimized two-pass OpenGL ES 3.1 pipeline powered by Snapdragon Game Super Resolution (SGSR).

Mobile devices, Android TVs, and Android-based gaming handhelds can greatly benefit from receiving a lower-resolution video stream while reconstructing a sharper final image locally on-device.  
This approach significantly reduces bandwidth usage, lowers decoder workload, and minimizes latency, while preserving excellent visual quality at the device's native resolution.

<img width="977" height="243" alt="image" src="https://github.com/user-attachments/assets/9c9a5b64-ee64-49be-855b-5c2e9e7bf8e1" />

---

## Technical Overview

Due to Android hardware decoding constraints, `MediaCodec` outputs frames to a `samplerExternalOES` texture, which is incompatible with standard 2D upscaling shaders.

To address this limitation, this PR introduces `GlesPassthroughBridge`, an efficient GPU-based two-pass pipeline:

1. **Pass 1 – Blit (OES → 2D):**  
   The hardware-decoded `samplerExternalOES` texture is rendered into a standard 2D texture using a Framebuffer Object (FBO).

2. **Pass 2 – Upscaling & Sharpening:**  
   The SGSR shader (`sgsr1_shader_mobile_edge_direction`) is applied to the 2D texture, producing a sharpened and upscaled image rendered to the display.

---

## Performance & Optimizations

Mobile GPUs are extremely sensitive to overhead, so this implementation includes several aggressive optimizations:

- **Compile-Time Constant Folding**  
  Stream resolution parameters are injected directly into GLSL via `#define` macros.  
  This eliminates per-frame computations and allows the compiler to fully optimize resolution-dependent math.

- **Vertex-Level Precomputation**  
  The vertex shader precomputes texture coordinates across the quad.  
  These values are interpolated by the GPU hardware, effectively providing per-fragment data at zero cost.

- **Zero Added VSync Latency**  
  EGL VSync is explicitly disabled (`eglSwapInterval(eglDisplay, 0)`) to avoid introducing additional frame latency in the streaming pipeline.

---

## Results

### 400% Zoom
Before
<img width="331" height="399" alt="Zoom_Original" src="https://github.com/user-attachments/assets/7694a1de-0f18-4a7d-95ca-da2df736e493" />

After
<img width="326" height="403" alt="Zoom_Upscaled" src="https://github.com/user-attachments/assets/3669d52b-1a62-4ccc-8415-ad1522f2fe72" />


### Original
<img width="1920" height="1080" alt="FreeboxTV_ORI" src="https://github.com/user-attachments/assets/73a381d3-d764-44c4-9cd6-a61d6b39b72d" />

### Video Super Resolution
<img width="1920" height="1080" alt="FreeboxTV_VSR" src="https://github.com/user-attachments/assets/f7e5af2a-af15-4c21-a7cd-837b323bc809" />

---

## Tests

This implementation was tested on two different classes of Android devices to evaluate performance across GPU tiers:

### 📱 Mobile – Realme Note 60 (Unisoc T612 / Mali-G57)
- **Baseline latency:** 9 ms  
- **With VSR:** 12 ms  
- **Impact:** ~+3 ms  

Performance on mobile is excellent, with very smooth rendering and minimal latency overhead.  
This demonstrates that mid-range mobile GPUs can handle SGSR upscaling efficiently in real-time.

---

### 📺 TV – Xiaomi TV F 32 (2026) (Cortex-A55 / Mali-G31 MP2)
- **Baseline latency:** 12 ms  
- **With VSR:** 26 ms  
- **Impact:** ~2x increase  

On lower-end TV GPUs, the performance impact is significantly more pronounced.  
Despite SGSR1 being one of the lightest and most optimized reconstruction upscalers available for mobile, entry-level GPUs such as the Mali-G31 struggle to sustain real-time performance without noticeable overhead.

---

These results highlight that while VSR is highly suitable for modern mobile GPUs, performance on low-end or TV-class hardware may vary and require further tuning or optional fallback strategies.

## Other VSR Implementations

VSR is also available in other Moonlight ports:

 - **Windows, macOS, Linux:** https://github.com/moonlight-stream/moonlight-qt/pull/1557
 
 - **iOS and tvOS:** https://github.com/moonlight-stream/moonlight-ios/pull/704

 - **Xbox:** https://github.com/TheElixZammuto/moonlight-xbox/pull/267