### PR TITLE
Fix Samsung keyboard trackpad cursor axes and add two-finger scroll support

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1826,7 +1826,6 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 // dealing with a stylus without hover support, our position might be
                 // significantly different than before.
                 if (inputCaptureProvider.eventHasRelativeMouseAxes(event)) {
-                    // Send the deltas straight from the motion event
                     float rawX = inputCaptureProvider.getRelativeAxisX(event);
                     float rawY = inputCaptureProvider.getRelativeAxisY(event);
 
@@ -1840,17 +1839,28 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                         rawY = -tmp;
                     }
 
-                    short deltaX = (short) rawX;
-                    short deltaY = (short) rawY;
-
-                    if (deltaX != 0 || deltaY != 0) {
-                        if (prefConfig.absoluteMouseMode) {
-                            // NB: view may be null, but we can unconditionally use streamView because we don't need to adjust
-                            // relative axis deltas for the position of the streamView within the parent's coordinate system.
-                            conn.sendMouseMoveAsMousePosition(deltaX, deltaY, (short)streamView.getWidth(), (short)streamView.getHeight());
+                    // Samsung keyboard trackpads send two-finger scroll as ACTION_MOVE with
+                    // getPointerCount() == 2, using the same REL_X/REL_Y axes as cursor movement
+                    // rather than ACTION_SCROLL with AXIS_VSCROLL/HSCROLL.
+                    if (eventSource == InputDevice.SOURCE_TOUCHPAD && event.getPointerCount() == 2) {
+                        if (rawX != 0 || rawY != 0) {
+                            int scrollDir = prefConfig.naturalScroll ? 1 : -1;
+                            conn.sendMouseHighResScroll((short)(rawY * 10 * scrollDir));
+                            conn.sendMouseHighResHScroll((short)(-rawX * 10 * scrollDir));
                         }
-                        else {
-                            conn.sendMouseMove(deltaX, deltaY);
+                    } else {
+                        short deltaX = (short) rawX;
+                        short deltaY = (short) rawY;
+
+                        if (deltaX != 0 || deltaY != 0) {
+                            if (prefConfig.absoluteMouseMode) {
+                                // NB: view may be null, but we can unconditionally use streamView because we don't need to adjust
+                                // relative axis deltas for the position of the streamView within the parent's coordinate system.
+                                conn.sendMouseMoveAsMousePosition(deltaX, deltaY, (short)streamView.getWidth(), (short)streamView.getHeight());
+                            }
+                            else {
+                                conn.sendMouseMove(deltaX, deltaY);
+                            }
                         }
                     }
                 }
@@ -1891,8 +1901,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 
                 if (event.getActionMasked() == MotionEvent.ACTION_SCROLL) {
                     // Send the vertical scroll packet
-                    conn.sendMouseHighResScroll((short)(event.getAxisValue(MotionEvent.AXIS_VSCROLL) * 120));
-                    conn.sendMouseHighResHScroll((short)(event.getAxisValue(MotionEvent.AXIS_HSCROLL) * 120));
+                    int scrollDir = prefConfig.naturalScroll ? -1 : 1;
+                    conn.sendMouseHighResScroll((short)(event.getAxisValue(MotionEvent.AXIS_VSCROLL) * 120 * scrollDir));
+                    conn.sendMouseHighResHScroll((short)(event.getAxisValue(MotionEvent.AXIS_HSCROLL) * 120 * scrollDir));
                 }
 
                 if ((changedButtons & MotionEvent.BUTTON_PRIMARY) != 0) {

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1827,8 +1827,21 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 // significantly different than before.
                 if (inputCaptureProvider.eventHasRelativeMouseAxes(event)) {
                     // Send the deltas straight from the motion event
-                    short deltaX = (short)inputCaptureProvider.getRelativeAxisX(event);
-                    short deltaY = (short)inputCaptureProvider.getRelativeAxisY(event);
+                    float rawX = inputCaptureProvider.getRelativeAxisX(event);
+                    float rawY = inputCaptureProvider.getRelativeAxisY(event);
+
+                    // Some keyboard trackpads (e.g. Samsung Galaxy Tab S11 Ultra Pro Keyboard)
+                    // report AXIS_RELATIVE_X/Y rotated 90° clockwise: the driver sends physical-Y
+                    // as AXIS_RELATIVE_X and physical-X as AXIS_RELATIVE_Y. Correcting means
+                    // reading Y as X and negating the new Y.
+                    if (prefConfig.rotateTouchpadAxes && eventSource == InputDevice.SOURCE_TOUCHPAD) {
+                        float tmp = rawX;
+                        rawX = rawY;
+                        rawY = -tmp;
+                    }
+
+                    short deltaX = (short) rawX;
+                    short deltaY = (short) rawY;
 
                     if (deltaX != 0 || deltaY != 0) {
                         if (prefConfig.absoluteMouseMode) {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -68,6 +68,7 @@ public class PreferenceConfiguration {
     private static final String GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING = "checkbox_gamepad_touchpad_as_mouse";
     private static final String GAMEPAD_MOTION_SENSORS_PREF_STRING = "checkbox_gamepad_motion_sensors";
     private static final String GAMEPAD_MOTION_FALLBACK_PREF_STRING = "checkbox_gamepad_motion_fallback";
+    private static final String ROTATE_TOUCHPAD_AXES_PREF_STRING = "checkbox_rotate_touchpad_axes";
 
     static final String DEFAULT_RESOLUTION = "1280x720";
     static final String DEFAULT_FPS = "60";
@@ -108,6 +109,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE = false;
     private static final boolean DEFAULT_GAMEPAD_MOTION_SENSORS = true;
     private static final boolean DEFAULT_GAMEPAD_MOTION_FALLBACK = false;
+    private static final boolean DEFAULT_ROTATE_TOUCHPAD_AXES = false;
 
     public static final int FRAME_PACING_MIN_LATENCY = 0;
     public static final int FRAME_PACING_BALANCED = 1;
@@ -155,6 +157,7 @@ public class PreferenceConfiguration {
     public boolean gamepadMotionSensors;
     public boolean gamepadTouchpadAsMouse;
     public boolean gamepadMotionSensorsFallbackToDevice;
+    public boolean rotateTouchpadAxes;
 
     public static boolean isNativeResolution(int width, int height) {
         // It's not a native resolution if it matches an existing resolution option
@@ -601,6 +604,7 @@ public class PreferenceConfiguration {
         config.gamepadTouchpadAsMouse = prefs.getBoolean(GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING, DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE);
         config.gamepadMotionSensors = prefs.getBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, DEFAULT_GAMEPAD_MOTION_SENSORS);
         config.gamepadMotionSensorsFallbackToDevice = prefs.getBoolean(GAMEPAD_MOTION_FALLBACK_PREF_STRING, DEFAULT_GAMEPAD_MOTION_FALLBACK);
+        config.rotateTouchpadAxes = prefs.getBoolean(ROTATE_TOUCHPAD_AXES_PREF_STRING, DEFAULT_ROTATE_TOUCHPAD_AXES);
 
         return config;
     }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -69,6 +69,7 @@ public class PreferenceConfiguration {
     private static final String GAMEPAD_MOTION_SENSORS_PREF_STRING = "checkbox_gamepad_motion_sensors";
     private static final String GAMEPAD_MOTION_FALLBACK_PREF_STRING = "checkbox_gamepad_motion_fallback";
     private static final String ROTATE_TOUCHPAD_AXES_PREF_STRING = "checkbox_rotate_touchpad_axes";
+    private static final String NATURAL_SCROLL_PREF_STRING = "checkbox_natural_scroll";
 
     static final String DEFAULT_RESOLUTION = "1280x720";
     static final String DEFAULT_FPS = "60";
@@ -110,6 +111,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_MOTION_SENSORS = true;
     private static final boolean DEFAULT_GAMEPAD_MOTION_FALLBACK = false;
     private static final boolean DEFAULT_ROTATE_TOUCHPAD_AXES = false;
+    private static final boolean DEFAULT_NATURAL_SCROLL = false;
 
     public static final int FRAME_PACING_MIN_LATENCY = 0;
     public static final int FRAME_PACING_BALANCED = 1;
@@ -158,6 +160,7 @@ public class PreferenceConfiguration {
     public boolean gamepadTouchpadAsMouse;
     public boolean gamepadMotionSensorsFallbackToDevice;
     public boolean rotateTouchpadAxes;
+    public boolean naturalScroll;
 
     public static boolean isNativeResolution(int width, int height) {
         // It's not a native resolution if it matches an existing resolution option
@@ -605,6 +608,7 @@ public class PreferenceConfiguration {
         config.gamepadMotionSensors = prefs.getBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, DEFAULT_GAMEPAD_MOTION_SENSORS);
         config.gamepadMotionSensorsFallbackToDevice = prefs.getBoolean(GAMEPAD_MOTION_FALLBACK_PREF_STRING, DEFAULT_GAMEPAD_MOTION_FALLBACK);
         config.rotateTouchpadAxes = prefs.getBoolean(ROTATE_TOUCHPAD_AXES_PREF_STRING, DEFAULT_ROTATE_TOUCHPAD_AXES);
+        config.naturalScroll = prefs.getBoolean(NATURAL_SCROLL_PREF_STRING, DEFAULT_NATURAL_SCROLL);
 
         return config;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,8 @@
     <string name="summary_checkbox_absolute_mouse_mode">This can make mouse acceleration behave more naturally for remote desktop usage, but it is incompatible with many games.</string>
     <string name="title_checkbox_rotate_touchpad_axes">Rotate external trackpad axes</string>
     <string name="summary_checkbox_rotate_touchpad_axes">Enable if your keyboard trackpad moves the cursor in the wrong direction (e.g. up/down movement causes left/right movement). Fixes devices like the Samsung Galaxy Tab Pro Keyboard.</string>
+    <string name="title_checkbox_natural_scroll">Invert scroll direction</string>
+    <string name="summary_checkbox_natural_scroll">Reverses the scroll direction for trackpad and mouse scroll wheel.</string>
     <string name="title_checkbox_mouse_nav_buttons">Enable back and forward mouse buttons</string>
     <string name="summary_checkbox_mouse_nav_buttons">Enabling this option may break right clicking on some buggy devices</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,8 @@
     <string name="summary_checkbox_touchscreen_trackpad">If enabled, the touchscreen acts like a trackpad. If disabled, the touchscreen directly controls the mouse cursor.</string>
     <string name="title_checkbox_absolute_mouse_mode">Remote desktop mouse mode</string>
     <string name="summary_checkbox_absolute_mouse_mode">This can make mouse acceleration behave more naturally for remote desktop usage, but it is incompatible with many games.</string>
+    <string name="title_checkbox_rotate_touchpad_axes">Rotate external trackpad axes</string>
+    <string name="summary_checkbox_rotate_touchpad_axes">Enable if your keyboard trackpad moves the cursor in the wrong direction (e.g. up/down movement causes left/right movement). Fixes devices like the Samsung Galaxy Tab Pro Keyboard.</string>
     <string name="title_checkbox_mouse_nav_buttons">Enable back and forward mouse buttons</string>
     <string name="summary_checkbox_mouse_nav_buttons">Enabling this option may break right clicking on some buggy devices</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -149,6 +149,11 @@
             android:title="@string/title_checkbox_rotate_touchpad_axes"
             android:summary="@string/summary_checkbox_rotate_touchpad_axes"
             android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_natural_scroll"
+            android:title="@string/title_checkbox_natural_scroll"
+            android:summary="@string/summary_checkbox_natural_scroll"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_on_screen_controls_settings"
         android:key="category_onscreen_controls">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -144,6 +144,11 @@
             android:title="@string/title_checkbox_absolute_mouse_mode"
             android:summary="@string/summary_checkbox_absolute_mouse_mode"
             android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_rotate_touchpad_axes"
+            android:title="@string/title_checkbox_rotate_touchpad_axes"
+            android:summary="@string/summary_checkbox_rotate_touchpad_axes"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_on_screen_controls_settings"
         android:key="category_onscreen_controls">


### PR DESCRIPTION
# Problem: 
On the Samsung Galaxy Tab S11 Ultra with the Pro Keyboard, the trackpad moves the cursor in the wrong direction — physical up moves the cursor right, and physical left moves it up. Bluetooth mice and the touchscreen trackpad mode are unaffected.

# Cause: 
The keyboard's driver reports AXIS_RELATIVE_X/Y rotated 90° clockwise relative to what Android expects — physical Y data comes through as X and vice versa.

# Fix: 
* Adds an opt-in toggle in Input Settings ("Rotate external trackpad axes") that corrects the axis mapping. It only applies to SOURCE_TOUCHPAD events and is off by default, so no existing behavior is affected.

* Two-finger scroll on the trackpad was being treated as cursor movement because Samsung's keyboard driver sends it as ACTION_MOVE with getPointerCount() == 2 rather than ACTION_SCROLL with AXIS_VSCROLL/HSCROLL. The fix detects two-finger events and routes them to scroll commands instead.

* An "Invert scroll direction" toggle has also been added to Input Settings, which reverses scroll direction for both trackpad two-finger scroll and standard mouse wheel (ACTION_SCROLL) events.



