### PR TITLE
Fix/mediatek smart tv hevc audio optimizations

### DIFF
--- a/app/src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.java
+++ b/app/src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.java
@@ -27,7 +27,8 @@ public class AndroidAudioRenderer implements AudioRenderer {
 
     private AudioTrack createAudioTrack(int channelConfig, int sampleRate, int bufferSize, boolean lowLatency) {
         AudioAttributes.Builder attributesBuilder = new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_GAME);
+                .setUsage(AudioAttributes.USAGE_GAME)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MOVIE);
         AudioFormat format = new AudioFormat.Builder()
                 .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                 .setSampleRate(sampleRate)
@@ -35,7 +36,9 @@ public class AndroidAudioRenderer implements AudioRenderer {
                 .build();
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            // Use FLAG_LOW_LATENCY on L through N
+            // Use FLAG_LOW_LATENCY on L through N. On Oreo+, PERFORMANCE_MODE_LOW_LATENCY
+            // supersedes this flag and setting both can cause crackling on some devices
+            // (e.g. Samsung Galaxy S21) due to conflicting requests to AudioFlinger.
             if (lowLatency) {
                 attributesBuilder.setFlags(AudioAttributes.FLAG_LOW_LATENCY);
             }
@@ -147,9 +150,11 @@ public class AndroidAudioRenderer implements AudioRenderer {
                     throw new IllegalStateException();
             }
 
-            // Skip low latency options if hardware sample rate doesn't match the content
-            if (AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC) != sampleRate && lowLatency) {
-                continue;
+            // Skip low latency options if hardware sample rate doesn't match the content (only required pre-Oreo)
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                if (AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC) != sampleRate && lowLatency) {
+                    continue;
+                }
             }
 
             // Skip low latency options when using audio effects, since low latency mode
@@ -187,15 +192,18 @@ public class AndroidAudioRenderer implements AudioRenderer {
 
     @Override
     public void playDecodedAudio(short[] audioData) {
-        // Only queue up to 40 ms of pending audio data in addition to what AudioTrack is buffering for us.
-        if (MoonBridge.getPendingAudioDuration() < 40) {
+        // Only queue up to 120 ms of pending audio data in addition to what AudioTrack is buffering for us.
+        // On many Android TV and mobile platforms, AudioTrack's recommended hardware buffer length is 60-100 ms.
+        // A low threshold like 40 ms mathematically guarantees constant packet drops during normal playback,
+        // manifesting as periodic stuttering. Using 120 ms absorbs the hardware buffer and brief network jitter safely.
+        if (MoonBridge.getPendingAudioDuration() < 120) {
             // This will block until the write is completed. That can cause a backlog
             // of pending audio data, so we do the above check to be able to bound
-            // latency at 40 ms in that situation.
+            // latency at 120 ms in that situation.
             track.write(audioData, 0, audioData.length);
         }
         else {
-            LimeLog.info("Too much pending audio data: " + MoonBridge.getPendingAudioDuration() +" ms");
+            LimeLog.info("Too much pending audio data (discarding): " + MoonBridge.getPendingAudioDuration() +" ms");
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -124,8 +124,11 @@ public class MediaCodecHelper {
         // if adaptive playback was enabled so let's avoid it to be safe.
         blacklistedAdaptivePlaybackPrefixes.add("omx.intel");
         // The MediaTek decoder crashes at 1080p when adaptive playback is enabled
-        // on some Android TV devices with HEVC only.
+        // on some Android TV devices with HEVC only. This applies to both OMX and C2 paths.
+        // omx.mtk is used by MediaTek mobile/tablet SoCs; omx.ms is used by MediaTek Smart TV SoCs (e.g. MT5889).
         blacklistedAdaptivePlaybackPrefixes.add("omx.mtk");
+        blacklistedAdaptivePlaybackPrefixes.add("c2.mtk");
+        blacklistedAdaptivePlaybackPrefixes.add("omx.ms");
 
         constrainedHighProfilePrefixes = new LinkedList<>();
         constrainedHighProfilePrefixes.add("omx.intel");
@@ -189,6 +192,14 @@ public class MediaCodecHelper {
         // We'll enable those HEVC decoders by default and see if anything breaks.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             whitelistedHevcDecoders.add("omx.realtek");
+        }
+
+        // MediaTek Smart TV SoCs (MT58xx/MT98xx series, used in TCL, Hisense, Philips, and others)
+        // use the "omx.ms" codec prefix rather than "omx.mtk". These chips have reliable HEVC decoders
+        // on Android 11 (R)+. FEATURE_LowLatency is used to select them at runtime; this entry serves
+        // as a fallback whitelist for devices that do not report that feature.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            whitelistedHevcDecoders.add("omx.ms");
         }
 
         // These theoretically have good HEVC decoding capabilities (potentially better than
@@ -412,6 +423,14 @@ public class MediaCodecHelper {
             }
         }
 
+        // MediaTek Smart TV SoCs (omx.ms prefix, e.g. MT5889) support HEVC RFI on Android 11+.
+        // Confirmed on TCL C735 (MT5889/Mali-G57). Unlike omx.mtk (mobile), omx.ms does not
+        // require GPU-family gating — all known omx.ms devices on Android R+ have reliable decoders.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            LimeLog.info("Added omx.ms to HEVC RFI list for MediaTek Smart TV SoCs (Android 11+)");
+            refFrameInvalidationHevcPrefixes.add("omx.ms");
+        }
+
         initialized = true;
     }
 
@@ -500,8 +519,16 @@ public class MediaCodecHelper {
 
         if (tryNumber < 1) {
             // Official Android 11+ low latency option (KEY_LOW_LATENCY).
-            videoFormat.setInteger("low-latency", 1);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                videoFormat.setInteger(MediaFormat.KEY_LOW_LATENCY, 1);
+            } else {
+                videoFormat.setInteger("low-latency", 1);
+            }
             setNewOption = true;
+
+            // Advise the decoder we are using a maximum of 0 B-frames and 1 pending/reference surface buffer
+            videoFormat.setInteger("max-bframes", 0);
+            videoFormat.setInteger("max-pending-frames", 1);
 
             // If this decoder officially supports FEATURE_LowLatency, we will just use that alone
             // for try 0. Otherwise, we'll include it as best effort with other options.


### PR DESCRIPTION
## Fix audio stuttering, extend MediaTek Smart TV HEVC support, and improve low-latency decoder options

### Audio: Fix periodic stuttering every ~2 seconds (`AndroidAudioRenderer`)

The pending audio drop threshold was 40ms. On Android TV and many mobile platforms, `AudioTrack`'s recommended hardware buffer size is 60–100ms. Because the threshold was smaller than the hardware buffer, `getPendingAudioDuration()` was always exceeded during a blocking `write()`, causing constant packet drops that manifested as periodic audio cutouts roughly every 2 seconds.

Raising the threshold to 120ms accommodates the full hardware buffer depth plus brief network jitter, while still bounding latency to prevent unbounded queue growth.

### Audio: Add `CONTENT_TYPE_MOVIE` hint

Add `CONTENT_TYPE_MOVIE` to `AudioAttributes` to hint to the Android audio mixer that this is media content. On some Android TV devices this prevents surround-virtualisation DSP post-processing from being applied, reducing audio pipeline latency.

### Audio: Restrict sample-rate mismatch guard to pre-Oreo

The guard that skips the low-latency path when the hardware sample rate doesn't match the content is no longer necessary on Oreo+. The AudioTrack resampler handles sample-rate conversion transparently on Oreo+, so skipping low-latency mode for a mismatch is unnecessary and harmful.

### Video: Extend MediaTek adaptive playback blacklist (`MediaCodecHelper`)

The existing `omx.mtk` adaptive playback blacklist (which prevents a 1080p HEVC decoder crash) was missing `c2.mtk` (the CCodec/C2 path for the same SoC family) and `omx.ms` (the MediaTek Smart TV SoC codec prefix, used by chips such as MT5889 found in TCL C735 and similar Google TV devices).

### Video: Enable HEVC and RFI for MediaTek Smart TV SoCs (`omx.ms`)

MediaTek Smart TV SoCs (MT58xx/MT98xx series, used in TCL, Hisense, Philips, and others) use the `omx.ms` codec prefix rather than `omx.mtk`. These devices were already selecting `omx.ms.hevc.decoder` via the `FEATURE_LowLatency` path, but Reference Frame Invalidation (RFI) was not enabled. Without RFI, packet-loss recovery requires waiting for the next IDR keyframe (500–2000ms); with RFI the stream recovers in 1–3 frames (~33–100ms). Both entries are gated on Android 11 (R)+ where these decoders are reliable.

### Video: Use `MediaFormat.KEY_LOW_LATENCY` constant on Android 11+

Replace the raw string `"low-latency"` with the documented `MediaFormat.KEY_LOW_LATENCY` constant on API 30+ to align with the public API.

### Video: Hint decoder to minimise output buffering

Set `max-bframes=0` and `max-pending-frames=1` as best-effort hints on decoders that respect them, to discourage unnecessary output surface queuing.

---

**Tested on:**
- TCL C735 (MT5889, `omx.ms.hevc.decoder`, Android 11 Google TV) — audio cutting resolved, HEVC RFI confirmed active
- Samsung Galaxy S21 (Android 12) — audio crackling confirmed absent with equalizer support disabled